### PR TITLE
Ask permissions + turn on coarse location tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/*.xcuserdata
 **/*.xcuserstate
+**/xcuserdata

--- a/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/actions/GeofenceActions.java
+++ b/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/actions/GeofenceActions.java
@@ -51,8 +51,8 @@ public class GeofenceActions {
     public PendingResult<Status> create() {
         Location mLastLocation = LocationServices.FusedLocationApi.getLastLocation(
                 mGoogleApiClient);
-        Log.d(TAG, "mLastLocation has elapsed time = "+mLastLocation.getElapsedRealtimeNanos());
         if (mLastLocation != null) {
+            Log.d(TAG, "mLastLocation has elapsed time = "+mLastLocation.getElapsedRealtimeNanos());
             Log.d(TAG, "Last location is " + mLastLocation + " creating geofence");
             // This is also an asynchronous call. We can either wait for the result,
             // or we can provide a callback. Let's provide a callback to keep the async

--- a/iOS/CFC_Tracker/CFC_Tracker.xcodeproj/project.pbxproj
+++ b/iOS/CFC_Tracker/CFC_Tracker.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 				TargetAttributes = {
 					D0EC6B471A7CBEBB00E8841B = {
 						CreatedOnToolsVersion = 6.1.1;
+						DevelopmentTeam = 9DZFVH97CB;
 						SystemCapabilities = {
 							com.apple.BackgroundModes = {
 								enabled = 1;
@@ -332,7 +333,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -368,7 +369,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -380,10 +381,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = CFC_Tracker/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Debug;
 		};
@@ -391,10 +395,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = CFC_Tracker/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 			};
 			name = Release;
 		};

--- a/iOS/CFC_Tracker/CFC_Tracker.xcodeproj/xcuserdata/shankari.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/iOS/CFC_Tracker/CFC_Tracker.xcodeproj/xcuserdata/shankari.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -9,13 +9,13 @@
             shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
-            filePath = "CFC_Tracker/TripDiaryStateMachine.m"
-            timestampString = "445156582.967275"
+            filePath = "CFC_Tracker/OngoingTripsDatabase.m"
+            timestampString = "445143444.127109"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "188"
-            endingLineNumber = "188"
-            landmarkName = "-locationManager:didUpdateLocations:"
+            startingLineNumber = "309"
+            endingLineNumber = "309"
+            landmarkName = "-getTransitions"
             landmarkType = "5">
          </BreakpointContent>
       </BreakpointProxy>
@@ -25,13 +25,13 @@
             shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
-            filePath = "CFC_Tracker/OngoingTripsDatabase.m"
-            timestampString = "445143444.127109"
+            filePath = "CFC_Tracker/TripDiaryStateMachine.m"
+            timestampString = "445762621.042196"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "309"
-            endingLineNumber = "309"
-            landmarkName = "-getTransitions"
+            startingLineNumber = "379"
+            endingLineNumber = "379"
+            landmarkName = "-locationManager:didDetermineState:forRegion:"
             landmarkType = "5">
          </BreakpointContent>
       </BreakpointProxy>

--- a/iOS/CFC_Tracker/CFC_Tracker/AppDelegate.m
+++ b/iOS/CFC_Tracker/CFC_Tracker/AppDelegate.m
@@ -21,6 +21,12 @@
     // Once the application has launched, set up a geofence around the current location
     _tripDiaryStateMachine = [[TripDiaryStateMachine alloc] init];
     
+    if ([UIApplication instancesRespondToSelector:@selector(registerUserNotificationSettings:)]) {
+        [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings
+                settingsForTypes:UIUserNotificationTypeAlert|UIUserNotificationTypeBadge
+                categories:nil]];
+    }
+    
     if ([launchOptions.allKeys containsObject:UIApplicationLaunchOptionsLocationKey]) {
         [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                    @"Application launched with LaunchOptionsLocationKey = YES"]];

--- a/iOS/CFC_Tracker/CFC_Tracker/Info.plist
+++ b/iOS/CFC_Tracker/CFC_Tracker/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Our app would like to collect your location information in the background</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.h
+++ b/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.h
@@ -39,6 +39,9 @@ typedef void(^GeofenceStatusCallback)(NSString* geofenceStatus);
 - (void)locationManager:(CLLocationManager *)manager
       didDetermineState:(CLRegionState)state forRegion:(CLRegion *)region;
 
+- (void)locationManager:(CLLocationManager *)manager
+    didChangeAuthorizationStatus:(CLAuthorizationStatus)status;
+
 -(void)handleTransition:(TripDiaryStateTransitions) transition;
 
 @end


### PR DESCRIPTION
The initial install of the app on my phone worked without asking for
permissions, but didn't work on Mogeng's phone. We now ask for permission for:
- location tracking
- displaying notification and badges

We also turn on coarse location tracking, which should cause the app to get
restarted if it is killed or if the phone is rebooted.

Bonus fixes:
- On android, move elapsedRealtimeNanos into null check code to avoid crash
- On iOS, switch the development environment to 7.1
- Notify the user if activity tracking is unavailable