### PR TITLE
Bunch of fixes after the first two weeks of running the app

### DIFF
--- a/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/BootReceiver.java
+++ b/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/BootReceiver.java
@@ -8,6 +8,8 @@ import android.preference.PreferenceManager;
 
 import java.io.IOException;
 
+import edu.berkeley.eecs.cfc_tracker.storage.DataUtils;
+
 /*
  * Class that allows us to re-register the alarms when the phone is rebooted.
  */
@@ -23,6 +25,13 @@ public class BootReceiver extends BroadcastReceiver {
             i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             System.out.println("Starting activity in boot receiver");
             ctx.startActivity(i);
+            /*
+             * End any ongoing trips, because the elapsed time will get reset at this
+             * point and invalidate all entries in the database.
+             * TODO: Remove this if we decide to switch back to utc time.
+             */
+            DataUtils.endTrip(ctx);
+
             // Re-initialize the state machine
             ctx.sendBroadcast(new Intent(ctx.getString(R.string.transition_initialize)));
 

--- a/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/MainActivity.java
+++ b/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/MainActivity.java
@@ -25,6 +25,7 @@ import com.google.android.gms.common.GooglePlayServicesUtil;
 import java.io.IOException;
 
 import edu.berkeley.eecs.cfc_tracker.auth.GoogleAccountManagerAuth;
+import edu.berkeley.eecs.cfc_tracker.auth.UserProfile;
 import edu.berkeley.eecs.cfc_tracker.location.TripDiaryStateMachineReceiver;
 import edu.berkeley.eecs.cfc_tracker.storage.OngoingTripStorageHelper;
 import edu.berkeley.eecs.cfc_tracker.storage.StoredTripHelper;
@@ -309,12 +310,9 @@ public class MainActivity extends Activity {
               if (resultCode == Activity.RESULT_OK) {
                   String userEmail = data.getStringExtra(AccountManager.KEY_ACCOUNT_NAME);
                   Toast.makeText(this, userEmail, Toast.LENGTH_SHORT).show();
-                  SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();
-                  editor.putString(getString(R.string.user_preferences_key_username), userEmail);
-                  editor.commit();
+                  UserProfile.getInstance(this).setUserEmail(userEmail);
                   Log.d(TAG, "After saving, username is "+
-                          PreferenceManager.getDefaultSharedPreferences(this).getString(
-                                  getString(R.string.user_preferences_key_username), ""));
+                          UserProfile.getInstance(this).getUserEmail());
               } else if (resultCode == Activity.RESULT_CANCELED) {
                   Toast.makeText(this, "You must pick an account", Toast.LENGTH_SHORT).show();
               }

--- a/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/auth/GoogleAccountManagerAuth.java
+++ b/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/auth/GoogleAccountManagerAuth.java
@@ -9,6 +9,7 @@ import com.google.android.gms.auth.UserRecoverableAuthException;
 import com.google.android.gms.common.AccountPicker;
 
 import edu.berkeley.eecs.cfc_tracker.ConnectionSettings;
+import edu.berkeley.eecs.cfc_tracker.Log;
 import edu.berkeley.eecs.cfc_tracker.R;
 import android.accounts.Account;
 import android.accounts.AccountManager;
@@ -27,6 +28,7 @@ public class GoogleAccountManagerAuth {
 
     Activity mCtxt;
     int mRequestCode;
+    public static String TAG = "GoogleAccountManagerAuth";
 
 	public GoogleAccountManagerAuth(Activity ctxt, int requestCode) {
 		mCtxt = ctxt;
@@ -70,7 +72,7 @@ public class GoogleAccountManagerAuth {
 	public static String getServerToken(Context context, String userName) {
 		String serverToken = null;
 		try {
-			String AUTH_SCOPE = ConnectionSettings.getGoogleWebAppClientID(context);
+			String AUTH_SCOPE = "audience:server:client_id:"+ConnectionSettings.getGoogleWebAppClientID(context);
 			serverToken = GoogleAuthUtil.getToken(context,
 					userName, AUTH_SCOPE);
 		} catch (UserRecoverableAuthException e) {

--- a/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/actions/ActivityRecognitionActions.java
+++ b/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/actions/ActivityRecognitionActions.java
@@ -19,7 +19,7 @@ import edu.berkeley.eecs.cfc_tracker.location.ActivityRecognitionChangeIntentSer
  */
 public class ActivityRecognitionActions {
     private static final int ACTIVITY_IN_NUMBERS = 22848489;
-    private static final int ACTIVITY_DETECTION_INTERVAL = Constants.THIRTY_SECONDS * 5;
+    private static final int ACTIVITY_DETECTION_INTERVAL = Constants.THIRTY_SECONDS;
     // ~ 2.5 minutes - the same change that we used to use to detect the end of a trip
 
     private static final String TAG = "ActivityRecognitionHandler";

--- a/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/smap/AddDataAdapter.java
+++ b/CFC_Tracker/app/src/main/java/edu/berkeley/eecs/cfc_tracker/smap/AddDataAdapter.java
@@ -27,6 +27,7 @@ import edu.berkeley.eecs.cfc_tracker.ConnectionSettings;
 import edu.berkeley.eecs.cfc_tracker.Constants;
 import edu.berkeley.eecs.cfc_tracker.R;
 import edu.berkeley.eecs.cfc_tracker.auth.GoogleAccountManagerAuth;
+import edu.berkeley.eecs.cfc_tracker.auth.UserProfile;
 import edu.berkeley.eecs.cfc_tracker.storage.DataUtils;
 
 import android.accounts.Account;
@@ -105,9 +106,9 @@ public class AddDataAdapter extends AbstractThreadedSyncAdapter {
 		}
 
         String emission_host = ConnectionSettings.getConnectURL(mContext);
-        String userName = PreferenceManager.getDefaultSharedPreferences(mContext).getString(
-                mContext.getString(R.string.user_preferences_key_username), ""
-        );
+        System.out.println("About to connect to host "+emission_host);
+
+        String userName = UserProfile.getInstance(mContext).getUserEmail();
         System.out.println("retrieved user name = "+userName);
 
         if (userName == null || userName.trim().equals("")) {


### PR DESCRIPTION
- end all existing trips on reboot because we are sorting trips based on
  elapsed time, and the elapsed time gets reset on reboot
- store the email in a file instead of in shared preferences. Since we cache
  the service context for later reuse, it looks like the email is not saved in
  the background data sync context unless it is selected before the service is
  created, which makes the code brittle
- Reverted the activity polling code to be 30 secs, since considering only the
  activities of interest seems to smooth out things pretty well, and we still
  want to quickly detect changes to avoid mixed trips
- Fixed horrible bug in the refactoring of the AUTH_SCOPE to not include the
  hardcoded client ID