### PR TITLE
Switch states to enum as well + some more changes to understand the iOS ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 **/*.xcuserdata
 **/*.xcuserstate
-**/xcuserdata
+**/xcuserdata/*

--- a/iOS/CFC_Tracker/CFC_Tracker.xcodeproj/xcuserdata/shankari.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/iOS/CFC_Tracker/CFC_Tracker.xcodeproj/xcuserdata/shankari.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -19,21 +19,5 @@
             landmarkType = "5">
          </BreakpointContent>
       </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "CFC_Tracker/TripDiaryStateMachine.m"
-            timestampString = "445762621.042196"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "379"
-            endingLineNumber = "379"
-            landmarkName = "-locationManager:didDetermineState:forRegion:"
-            landmarkType = "5">
-         </BreakpointContent>
-      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/iOS/CFC_Tracker/CFC_Tracker/AppDelegate.m
+++ b/iOS/CFC_Tracker/CFC_Tracker/AppDelegate.m
@@ -46,10 +46,14 @@
 - (void)applicationDidEnterBackground:(UIApplication *)application {
     // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
     // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                               @"Application went to the background"]];
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
     // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                               @"Application will enter the background"]];
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
@@ -58,6 +62,9 @@
 
 - (void)applicationWillTerminate:(UIApplication *)application {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                               @"Application is about to terminate"]];
+
 }
 
 @end

--- a/iOS/CFC_Tracker/CFC_Tracker/Base.lproj/Main.storyboard
+++ b/iOS/CFC_Tracker/CFC_Tracker/Base.lproj/Main.storyboard
@@ -52,7 +52,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="hfX-qk-0Wc">
-                                <rect key="frame" x="16" y="105" width="568" height="479"/>
+                                <rect key="frame" x="16" y="134" width="568" height="450"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </tableView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Trip state" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wUd-vr-IqI">
@@ -88,6 +88,17 @@
                                     <action selector="resetStateMachine:" destination="BYZ-38-t0r" eventType="touchUpInside" id="EHh-12-5Rq"/>
                                 </connections>
                             </button>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="zni-Mi-a2U">
+                                <rect key="frame" x="20" y="98" width="175" height="29"/>
+                                <segments>
+                                    <segment title="Geofence"/>
+                                    <segment title="Loc Change"/>
+                                </segments>
+                                <connections>
+                                    <action selector="switchMode:" destination="BYZ-38-t0r" eventType="valueChanged" id="L1z-6X-5p3"/>
+                                    <action selector="switchStateMachineMode:" destination="BYZ-38-t0r" eventType="valueChanged" id="DyS-8P-nEd"/>
+                                </connections>
+                            </segmentedControl>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>

--- a/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.h
+++ b/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.h
@@ -17,13 +17,20 @@ typedef enum : NSUInteger {
     kTransitionStopTracking
 } TripDiaryStateTransitions;
 
+typedef enum : NSUInteger {
+    kStartState,
+    kWaitingForTripStartState,
+    kOngoingTripState
+} TripDiaryStates;
+
 typedef void(^GeofenceStatusCallback)(NSString* geofenceStatus);
 
 @interface TripDiaryStateMachine : NSObject <CLLocationManagerDelegate>
 
-@property NSString* currState;
+@property TripDiaryStates currState;
 
 + (NSString*)getTransitionName:(TripDiaryStateTransitions) transition;
++ (NSString*)getStateName:(TripDiaryStates) state;
 
 - (void)checkGeofenceState:(GeofenceStatusCallback) resultField;
 
@@ -41,6 +48,20 @@ typedef void(^GeofenceStatusCallback)(NSString* geofenceStatus);
 
 - (void)locationManager:(CLLocationManager *)manager
     didChangeAuthorizationStatus:(CLAuthorizationStatus)status;
+
+- (void)locationManager:(CLLocationManager *)manager
+               didVisit:(CLVisit *)visit;
+
+- (void)locationManagerDidPauseLocationUpdates:(CLLocationManager *)manager;
+
+- (void)locationManagerDidResumeLocationUpdates:(CLLocationManager *)manager;
+
+- (void)locationManager:(CLLocationManager *)manager
+        monitoringDidFailForRegion:(CLRegion *)region
+             withError:(NSError *)error;
+
+- (void)locationManager:(CLLocationManager *)manager
+       didUpdateHeading:(CLHeading *)newHeading;
 
 -(void)handleTransition:(TripDiaryStateTransitions) transition;
 

--- a/iOS/CFC_Tracker/CFC_Tracker/ViewController.m
+++ b/iOS/CFC_Tracker/CFC_Tracker/ViewController.m
@@ -50,7 +50,7 @@
 }
 
 - (IBAction)refreshState:(id)sender {
-    NSString* refreshedState = [self getTDSM].currState;
+    NSString* refreshedState = [TripDiaryStateMachine getStateName:[self getTDSM].currState];
     self.tdsrmCurrState.text = refreshedState;
     [self.transitionTable reloadData];
 }
@@ -58,6 +58,10 @@
 - (IBAction)clearTransitions:(id)sender {
     [[OngoingTripsDatabase database] clearTransitions];
     [self.transitionTable reloadData];
+}
+
+- (IBAction)switchStateMachineMode:(id)sender {
+    
 }
 
 - (TripDiaryStateMachine*) getTDSM {


### PR DESCRIPTION
...lifecycle

- Add notifications about the application lifecycle to understand how they are
  related to
- Add a control that should allow us to switch between significant location
  changes and the geofence - the control is currently not hooked up to anything
- Switched the states to an enum as well to allow == to work. This appeared to
  work even with strings on an iPhone4 but not on an iPhone6.
- Added support for the visit API, and callbacks for all the delegate methods
  to fully understand the location workflow