### PR TITLE
Turn on phone-based activity tracking on iOS

### DIFF
--- a/iOS/CFC_Tracker/CFC_Tracker.xcodeproj/project.pbxproj
+++ b/iOS/CFC_Tracker/CFC_Tracker.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		D062E7BB1ABB1039009373BF /* TripDiaryStateMachineTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D062E7BA1ABB1039009373BF /* TripDiaryStateMachineTests.m */; };
 		D062E7BD1AC4CFAE009373BF /* DataUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D062E7BC1AC4CFAE009373BF /* DataUtilsTests.m */; };
 		D062E7C01AC4D619009373BF /* TestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = D062E7BF1AC4D619009373BF /* TestUtils.m */; };
+		D062E7C31ACA50DA009373BF /* EMActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = D062E7C21ACA50DA009373BF /* EMActivity.m */; };
 		D06C946A1A858F2600D9CCC0 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D06C94691A858F2600D9CCC0 /* libsqlite3.dylib */; };
 		D06C94701A86672E00D9CCC0 /* OngoingTripsDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = D06C946F1A86672E00D9CCC0 /* OngoingTripsDatabase.m */; };
 		D06C94721A8844B800D9CCC0 /* OngoingTripsAuto.db in Resources */ = {isa = PBXBuildFile; fileRef = D06C94711A8844B800D9CCC0 /* OngoingTripsAuto.db */; };
@@ -27,6 +28,7 @@
 		D06DDAA11AB512DB00E6CF9B /* CommunicationHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = D06DDA9E1AB512DB00E6CF9B /* CommunicationHelper.m */; };
 		D06DDAA21AB512DB00E6CF9B /* CustomSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = D06DDAA01AB512DB00E6CF9B /* CustomSettings.m */; };
 		D06DDAA51AB516B900E6CF9B /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = D06DDAA41AB516B900E6CF9B /* Constants.m */; };
+		D07790811ACB04C700634A05 /* EMActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = D062E7C21ACA50DA009373BF /* EMActivity.m */; };
 		D0A74D7E1AA786CA005BE6B2 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0A74D7D1AA786CA005BE6B2 /* Bolts.framework */; };
 		D0A74D801AA786DB005BE6B2 /* Parse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0A74D7F1AA786DB005BE6B2 /* Parse.framework */; };
 		D0A74D821AA78CA1005BE6B2 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0A74D811AA78CA1005BE6B2 /* AudioToolbox.framework */; };
@@ -63,6 +65,8 @@
 		D062E7BC1AC4CFAE009373BF /* DataUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DataUtilsTests.m; sourceTree = "<group>"; };
 		D062E7BE1AC4D619009373BF /* TestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestUtils.h; sourceTree = "<group>"; };
 		D062E7BF1AC4D619009373BF /* TestUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TestUtils.m; path = CFC_TrackerTests/TestUtils.m; sourceTree = SOURCE_ROOT; };
+		D062E7C11ACA50DA009373BF /* EMActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EMActivity.h; sourceTree = "<group>"; };
+		D062E7C21ACA50DA009373BF /* EMActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EMActivity.m; sourceTree = "<group>"; };
 		D06C94691A858F2600D9CCC0 /* libsqlite3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsqlite3.dylib; path = usr/lib/libsqlite3.dylib; sourceTree = SDKROOT; };
 		D06C946E1A86672E00D9CCC0 /* OngoingTripsDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OngoingTripsDatabase.h; sourceTree = "<group>"; };
 		D06C946F1A86672E00D9CCC0 /* OngoingTripsDatabase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OngoingTripsDatabase.m; sourceTree = "<group>"; };
@@ -203,6 +207,8 @@
 				D0EC6B721A7D57D300E8841B /* TripDiaryStateMachine.m */,
 				D06DDA7E1AAC0B8400E6CF9B /* TripDiaryActions.h */,
 				D06DDA7F1AAC0B8400E6CF9B /* TripDiaryActions.m */,
+				D062E7C11ACA50DA009373BF /* EMActivity.h */,
+				D062E7C21ACA50DA009373BF /* EMActivity.m */,
 			);
 			name = Location;
 			sourceTree = "<group>";
@@ -404,6 +410,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D07790811ACB04C700634A05 /* EMActivity.m in Sources */,
 				D06DDA981AB510BD00E6CF9B /* SignInViewController.m in Sources */,
 				D06DDA931AB510AF00E6CF9B /* AuthCompletionHandler.m in Sources */,
 				D0EC6B781A80984500E8841B /* LocalNotificationManager.m in Sources */,
@@ -432,6 +439,7 @@
 				D062E7BB1ABB1039009373BF /* TripDiaryStateMachineTests.m in Sources */,
 				D0EC6B681A7CBEBB00E8841B /* CFC_TrackerTests.m in Sources */,
 				D062E7C01AC4D619009373BF /* TestUtils.m in Sources */,
+				D062E7C31ACA50DA009373BF /* EMActivity.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/CFC_Tracker/CFC_Tracker/DataUtils.h
+++ b/iOS/CFC_Tracker/CFC_Tracker/DataUtils.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreLocation/CoreLocation.h>
+#import "EMActivity.h"
 
 @interface DataUtils : NSObject
 + (NSString*)dateToString:(NSDate*)date;
@@ -16,6 +17,9 @@
 
 + (void) addPoint:(CLLocation*) currLoc;
 + (NSArray*) getLastPoints:(int) nPoints;
+
++ (void) addModeChange:(EMActivity*) activity;
+
 + (void) clearOngoingDb;
 + (void) clearStoredDb;
 

--- a/iOS/CFC_Tracker/CFC_Tracker/EMActivity.h
+++ b/iOS/CFC_Tracker/CFC_Tracker/EMActivity.h
@@ -1,0 +1,34 @@
+//
+//  EMActivity.h
+//  CFC_Tracker
+//
+//  Created by Kalyanaraman Shankari on 3/30/15.
+//  Copyright (c) 2015 Kalyanaraman Shankari. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreMotion/CoreMotion.h>
+
+typedef enum : NSUInteger {
+    kTransportActivity,
+    kCyclingActivity,
+    kWalkingActivity,
+    kUnknownActivity
+} TripActivityStates;
+
+/*
+ * Our version of CMMotionActivity. Created because of difficulties with mocking CMMotionActivity
+ * for the purposes of testing. This also allows us to deserialize this from the database.
+ */
+
+@interface EMActivity : NSObject
+
+@property TripActivityStates mode;
+@property CMMotionActivityConfidence confidence;
+@property NSDate* startDate;
+- (NSString*)getActivityName;
+
++ (NSString*)getActivityName:(TripActivityStates) mode;
++ (TripActivityStates)getRelevantActivity:(CMMotionActivity*) activity;
+
+@end

--- a/iOS/CFC_Tracker/CFC_Tracker/EMActivity.m
+++ b/iOS/CFC_Tracker/CFC_Tracker/EMActivity.m
@@ -1,0 +1,53 @@
+//
+//  EMActivity.m
+//  CFC_Tracker
+//
+//  Created by Kalyanaraman Shankari on 3/30/15.
+//  Copyright (c) 2015 Kalyanaraman Shankari. All rights reserved.
+//
+
+#import "EMActivity.h"
+
+@interface EMActivity()
+@end
+
+@implementation EMActivity
+
+-(id)init {
+    self.mode = kUnknownActivity;
+    self.confidence = CMMotionActivityConfidenceLow;
+    self.startDate = [NSDate date];
+    return [super init];
+}
+
+- (NSString*)getActivityName {
+    return [EMActivity getActivityName:self.mode];
+}
+
++ (NSString*)getActivityName:(TripActivityStates) mode {
+    if(mode == kWalkingActivity) {
+        return @"walking";
+    } else if (mode == kCyclingActivity) {
+        return @"cycling";
+    } else if (mode == kTransportActivity) {
+        return @"transport";
+    } else {
+        return @"unknown";
+    }
+}
+
++ (TripActivityStates)getRelevantActivity:(CMMotionActivity*) activity {
+    if (activity.automotive == YES) {
+        return kTransportActivity;
+    } else if (activity.cycling == YES) {
+        return kCyclingActivity;
+    } else if (activity.walking == YES) {
+        return kWalkingActivity;
+    } else {
+        return kUnknownActivity;
+    }
+}
+
+
+
+@end

--- a/iOS/CFC_Tracker/CFC_Tracker/OngoingTripsDatabase.h
+++ b/iOS/CFC_Tracker/CFC_Tracker/OngoingTripsDatabase.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <sqlite3.h>
 #import <CoreLocation/CoreLocation.h>
-#import <CoreMotion/CoreMotion.h>
+#import "EMActivity.h"
 
 @interface OngoingTripsDatabase : NSObject {
     sqlite3 *_database;
@@ -31,15 +31,10 @@
 -(NSArray*)getTransitions;
 -(void)clearTransitions;
 
-// It is unclear whether we need to store the modes on iOS, or whether we can just use
-// the existing query method to read the modes that iOS has already stored.
-// In particular,
-// -(void) addModeChange:(CMMotionActivity*) activity;
-// -(NSArray*) getModeChanges;
+// We can use the existing query method to read the activities that iOS has already stored.
+// However, it is not possible for
 
+-(void) addModeChange:(EMActivity*) activity;
+-(NSArray*) getModeChanges:(NSDate*) date toDate:(NSDate*) toDate;
 
-/*
-- (void) startTrip:(NSString*) mode;
-- (NSDictionary*) getOngoingTrip;
-*/
 @end

--- a/iOS/CFC_Tracker/CFC_Tracker/TripDiaryActions.m
+++ b/iOS/CFC_Tracker/CFC_Tracker/TripDiaryActions.m
@@ -48,7 +48,7 @@
 + (void) stopTracking:(NSString*) transition withLocationMgr:(CLLocationManager*)locMgr
                                              withActivityMgr:(CMMotionActivityManager*)activityMgr {
     [self stopTrackingLocation:locMgr];
-//    [self stopTrackingActivity:activityMgr];
+    [self stopTrackingActivity:activityMgr];
     [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
                                                         object:CFCTransitionTripEnded];
 }

--- a/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.m
+++ b/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.m
@@ -236,6 +236,7 @@ static NSString * const kCurrState = @"CURR_STATE";
         [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
                                                             object:CFCTransitionTripEnded];
     } else if ([transition isEqualToString:CFCTransitionTripEnded]) {
+        // TODO: Should this be here, or in EndTripTracking
         [self setState:kWaitingForTripStartState];        
         [TripDiaryActions pushTripToServer];
     } else if ([transition isEqualToString:CFCTransitionForceStopTracking]) {

--- a/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.m
+++ b/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.m
@@ -15,16 +15,6 @@
 #import "OngoingTripsDatabase.h"
 #import <CoreMotion/CoreMotion.h>
 
-
-/*
-@interface TripDiaryStateMachine() {
-    CLLocationManager *locMgr;
-    CMMotionActivityManager *activityMgr;
-    TripDiaryDelegate* _locDelegate;
-}
-@end
-*/
-
 @interface TripDiaryStateMachine() {
     TripDiaryDelegate* _locDelegate;
 }
@@ -48,7 +38,7 @@ static NSString * const kCurrState = @"CURR_STATE";
     }
 }
 
--(id)init{
+-(id)init {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     self.currState = [defaults integerForKey:kCurrState];
     
@@ -89,14 +79,6 @@ static NSString * const kCurrState = @"CURR_STATE";
         }
     }
     
-    if ([CMMotionActivityManager isActivityAvailable] == YES) {
-        self.activityMgr = [[CMMotionActivityManager alloc] init];
-    } else {
-        NSLog(@"UIAlertView: Activity recognition unavailable");
-        [TripDiaryStateMachine showAlert:@"Activity recognition is not available on your phone"
-                               withTitle:@"Activity recognition disabled"];
-    }
-
     /*
      * Make sure that we start with a clean state, at least while debugging.
      * TODO: Check how often this is initialized, and whether we should do this even when we are out of debugging.
@@ -254,8 +236,7 @@ static NSString * const kCurrState = @"CURR_STATE";
         [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
                                                             object:CFCTransitionTripEnded];
     } else if ([transition isEqualToString:CFCTransitionTripEnded]) {
-        [self setState:kWaitingForTripStartState];
-        // TODO: Should this be here, or in EndTripTracking
+        [self setState:kWaitingForTripStartState];        
         [TripDiaryActions pushTripToServer];
     } else if ([transition isEqualToString:CFCTransitionForceStopTracking]) {
         [TripDiaryActions resetFSM:transition withLocationMgr:self.locMgr withActivityMgr:self.activityMgr];


### PR DESCRIPTION
This commit turns on phone-based activity tracking on iOS.

However, since the CMMotionActivity class has only read-only properties, it was
fairly challenging to unit test it. I did so by creating a class of my own
(EMActivity, for E-Mission activity) that has very similar data. I also put the
data from the CMMotionActivityManager into the database and segment based on
the values in the database.

This allowed me to write a segmentation based unit test, which works.

When I tested it on a real iphone, however, I did not get any activity data for
the past 4 hours in response to my query. This was in spite of the iOS
documentation that said that the phone continuously collects activity data in
the background, even when not requested by any apps.

This needs to be investigated further, but I had to return my borrowed iPhone6.
Fortunately, test phones are "almost here".

In the meanwhile, if there is no activity information, we fall back on sending
the full set of GPS points for the trip to the server, since we should be able
to segment there using Francois' code.

This will also allow us to work on iPhone4+ instead of iPhone5s+ devices.