### PR TITLE
Loc fix

### DIFF
--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/LocationChangeIntentService.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/LocationChangeIntentService.java
@@ -47,6 +47,17 @@ public class LocationChangeIntentService extends IntentService {
         Log.d(TAG, "Intent Action is "+intent);
 
 		Location loc = (Location)intent.getExtras().get(FusedLocationProviderApi.KEY_LOCATION_CHANGED);
+
+		/*
+		It seems that newer version of Google Play will send along an intent that does not have the
+		KEY_LOCATION_CHANGED extra, but rather an EXTRA_LOCATION_AVAILABILITY. The original code
+		assumed KEY_LOCATION_CHANGED would always be there, and didn't check for this other type
+		of extra. I think we can safely ignore these intents and just return when loc is null.
+
+		see http://stackoverflow.com/questions/29960981/why-does-android-fusedlocationproviderapi-requestlocationupdates-send-updates-wi
+		 */
+		if (loc == null) return;
+
 		DataUtils.addPoint(this, loc);
 		if (isTripEnded()) {
 			// Stop listening to more updates


### PR DESCRIPTION
My data-collector kept dying on my phone (several times a day). I hunted down the error to LocationChangeIntentService where it grabs an extra from the passed in intent but doesn't check that the extra actually exists, so later on you get a NullPointerException when you try to access it. Right now this code just exits if the passed in intent doesn't have the right data. See the SO link in the code for details. (please ignore all the weird commits prior to the final one, it was me fighting git).