### PR TITLE
Add some additional logging to help debug a corner case

### DIFF
--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineReceiver.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineReceiver.java
@@ -136,6 +136,9 @@ public class TripDiaryStateMachineReceiver extends BroadcastReceiver
                 PreferenceManager.getDefaultSharedPreferences(mContext).edit();
         prefsEditor.putString(CURR_STATE_KEY, newState);
         prefsEditor.apply();
+        Log.d(mContext, TAG, "newState saved in prefManager is "+
+            PreferenceManager.getDefaultSharedPreferences(mContext).getString(
+                    CURR_STATE_KEY, "not found"));
     }
 
 	@Override


### PR DESCRIPTION
It looks like SharedPreferences do not save properly in some cases.
Here's what I saw from the app logs for a trip in which I left Tied House at 8:30pm and came home.
The app appeared to have been killed and relaunched by the geofence exit, since the id was 9.

    [9|1435807867723|7/1/15 8:31 PM|FINE]TripDiaryStateMachineReceiver : after reading from the prefs, the current state is local.state.waiting_for_trip_start

After processing the geofence exit, the new state was ongoing_trip.

    [14|1435807867853|7/1/15 8:31 PM|FINE]TripDiaryStateMachineReceiver : newState after handling action is local.state.ongoing_trip

However, when the state is next read, it is still waiting_for_trip_start

    [87|1435808413146|7/1/15 8:40 PM|FINE]TripDiaryStateMachineReceiver : after reading from the prefs, the current state is local.state.waiting_for_trip_start

So when the trip end is detected, we think that the current state is already waiting_for_trip_start, so we do not turn off ongoing tracking, and we do not establish the geofence.

Adding some additional logging to help debug this further.