### PR TITLE
Clean up storage of the sensor data read from the phone

### DIFF
--- a/android/app/src/androidTest/java/edu/berkeley/eecs/cfc_tracker/test/location/LocationTests.java
+++ b/android/app/src/androidTest/java/edu/berkeley/eecs/cfc_tracker/test/location/LocationTests.java
@@ -183,8 +183,8 @@ public class LocationTests extends ActivityInstrumentationTestCase2<MainActivity
 
         System.out.println("ASSERT: Got "+uc.getLastMessages(R.string.key_usercache_location, 2,
                 Location.class).length+" points");
-		assertEquals(uc.getLastMessages(R.string.key_usercache_location, 2,
-                Location.class).length, 1);
+		assertEquals(1, uc.getLastMessages(R.string.key_usercache_location, 2,
+                Location.class).length);
 
         startTime = System.currentTimeMillis();
 		final BroadcastChecker enterChecker = new BroadcastChecker(stopString);

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/ActivityRecognitionChangeIntentService.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/ActivityRecognitionChangeIntentService.java
@@ -45,7 +45,7 @@ public class ActivityRecognitionChangeIntentService extends IntentService {
 			// better.
             // if (mostProbableActivity.getConfidence() > 90) {
                 UserCache userCache = UserCacheFactory.getUserCache(this);
-                userCache.putMessage(R.string.key_usercache_activity, mostProbableActivity);
+                userCache.putSensorData(R.string.key_usercache_activity, mostProbableActivity);
             // }
 			/*
 			DetectedActivity currentActivity = DataUtils.getCurrentMode(this).getLastActivity();

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/GeofenceExitIntentService.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/GeofenceExitIntentService.java
@@ -51,7 +51,7 @@ public class GeofenceExitIntentService extends IntentService {
         if (parsedEvent.getGeofenceTransition() == Geofence.GEOFENCE_TRANSITION_EXIT) {
     		Log.d(this, TAG, "Geofence exited! Intent = "+ intent+" Starting ongoing monitoring...");
             // Add the exit location to the tracking database
-			UserCacheFactory.getUserCache(this).putMessage(R.string.key_usercache_location,
+			UserCacheFactory.getUserCache(this).putSensorData(R.string.key_usercache_location,
                     parsedEvent.getTriggeringLocation());
             // DataUtils.addPoint(this, parsedEvent.getTriggeringLocation());
             // Let's just re-use the same event for the broadcast, since it has the location information

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/GeofenceExitIntentService.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/GeofenceExitIntentService.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 
 import edu.berkeley.eecs.cfc_tracker.log.Log;
 import edu.berkeley.eecs.cfc_tracker.usercache.UserCacheFactory;
+import edu.berkeley.eecs.cfc_tracker.wrapper.SimpleLocation;
 
 import com.google.android.gms.location.Geofence;
 import com.google.android.gms.location.GeofencingEvent;
@@ -52,7 +53,7 @@ public class GeofenceExitIntentService extends IntentService {
     		Log.d(this, TAG, "Geofence exited! Intent = "+ intent+" Starting ongoing monitoring...");
             // Add the exit location to the tracking database
 			UserCacheFactory.getUserCache(this).putSensorData(R.string.key_usercache_location,
-                    parsedEvent.getTriggeringLocation());
+                    new SimpleLocation(parsedEvent.getTriggeringLocation()));
             // DataUtils.addPoint(this, parsedEvent.getTriggeringLocation());
             // Let's just re-use the same event for the broadcast, since it has the location information
             // in case we need it on the other side.

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/LocationChangeIntentService.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/LocationChangeIntentService.java
@@ -71,7 +71,7 @@ public class LocationChangeIntentService extends IntentService {
 		 */
 		if (loc == null) return;
 
-        uc.putMessage(R.string.key_usercache_location, loc);
+        uc.putSensorData(R.string.key_usercache_location, loc);
 
         /*
 		 * So far, our analysis for detecting the end of a trip starts off with ignoring points with
@@ -81,13 +81,13 @@ public class LocationChangeIntentService extends IntentService {
 		 * location and use the filtered location for our calculations.
 		 */
 
-        Location[] last10Points = uc.getLastMessages(R.string.key_usercache_filtered_location, 10, Location.class);
+        Location[] last10Points = uc.getLastSensorData(R.string.key_usercache_filtered_location, 10, Location.class);
         Long nowMs = System.currentTimeMillis();
         UserCache.TimeQuery tq = new UserCache.TimeQuery(R.string.metadata_usercache_write_ts,
                 nowMs - FIVE_MINUTES_IN_MS - 10, nowMs);
 
         Log.d(this, TAG, "Finding points in the range "+tq);
-        Location[] points5MinsAgo = uc.getMessagesForInterval(R.string.key_usercache_filtered_location,
+        Location[] points5MinsAgo = uc.getSensorDataForInterval(R.string.key_usercache_filtered_location,
                 tq, Location.class);
 
         boolean validPoint = false;
@@ -111,7 +111,7 @@ public class LocationChangeIntentService extends IntentService {
         Log.d(this, TAG, "Current point status = "+validPoint);
 
         if (validPoint) {
-            uc.putMessage(R.string.key_usercache_filtered_location, loc);
+            uc.putSensorData(R.string.key_usercache_filtered_location, loc);
         }
 
         // We will check whether the trip ended only when the point is valid.

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/sensors/BatteryPollSensor.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/sensors/BatteryPollSensor.java
@@ -12,6 +12,6 @@ import edu.berkeley.eecs.cfc_tracker.usercache.UserCacheFactory;
 public class BatteryPollSensor implements PollSensor {
     public void getAndSaveValue(Context ctxt) {
         float currLevel = BatteryUtils.getBatteryLevel(ctxt);
-        UserCacheFactory.getUserCache(ctxt).putMessage(R.string.key_usercache_battery, currLevel);
+        UserCacheFactory.getUserCache(ctxt).putSensorData(R.string.key_usercache_battery, currLevel);
     }
 }

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/usercache/UserCache.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/usercache/UserCache.java
@@ -26,6 +26,8 @@ public interface UserCache {
       Most objects are, but it would be good to confirm, probably by
       adding a serialization/deserialization test to WrapperTest.
      */
+    public abstract void putSensorData(int keyRes, Object value);
+
     public abstract void putMessage(int keyRes, Object value);
 
     public abstract void putReadWriteDocument(int keyRes, Object value);
@@ -33,7 +35,10 @@ public interface UserCache {
     // TODO: Should this return a JSON object or an actual object retrieved via gson?
 
     public abstract <T> T[] getMessagesForInterval(int keyRes, TimeQuery tq, Class<T> classOfT);
+    public abstract <T> T[] getSensorDataForInterval(int keyRes, TimeQuery tq, Class<T> classOfT);
+
     public abstract <T> T[] getLastMessages(int keyRes, int nEntries, Class<T> classOfT);
+    public abstract <T> T[] getLastSensorData(int keyRes, int nEntries, Class<T> classOfT);
 
         /**
          * Return the document that matches the specified key.

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/wrapper/SimpleLocation.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/wrapper/SimpleLocation.java
@@ -1,0 +1,62 @@
+package edu.berkeley.eecs.cfc_tracker.wrapper;
+
+import android.location.Location;
+
+import java.text.SimpleDateFormat;
+
+/**
+ * Created by shankari on 8/30/15.
+ */
+public class SimpleLocation {
+    public double getLatitude() {
+        return latitude;
+    }
+
+    public double getLongitude() {
+        return longitude;
+    }
+
+    public long getTs() {
+        return ts;
+    }
+
+    private double latitude;
+    private double longitude;
+    private double altitude;
+
+    private long ts;
+    private String fmt_time;
+    private long elapsedRealtimeNanos;
+
+    private float sensed_speed;
+    private float accuracy;
+    private float bearing;
+
+    private String provider;
+
+    /*
+     * No-arg constructor to use with gson.
+     * If this works, consider switching to a custom serializer instead.
+     */
+    public SimpleLocation() {}
+
+    public SimpleLocation(Location loc) {
+        latitude = loc.getLatitude();
+        longitude = loc.getLongitude();
+        altitude = loc.getAltitude();
+
+        ts = loc.getTime();
+        fmt_time = SimpleDateFormat.getDateTimeInstance().format(ts);
+        elapsedRealtimeNanos = loc.getElapsedRealtimeNanos();
+
+        sensed_speed = loc.getSpeed();
+        accuracy = loc.getAccuracy();
+        bearing = loc.getBearing();
+    }
+
+    public float distanceTo(SimpleLocation dest) {
+        float[] results = new float[1];
+        Location.distanceBetween(latitude, longitude, dest.getLatitude(), dest.getLongitude(), results);
+        return results[0];
+    }
+}


### PR DESCRIPTION
1. Change the sensor data to have type `sensor-data` instead of `message`. To be consistent with our design guidelines.
2. We also get to separate out the read-only parts from the read-write parts of our progressive system.