### PR TITLE
Switch to handling most of the functionality of the trip diary state …

### DIFF
--- a/android/app/src/androidTest/java/edu/berkeley/eecs/cfc_tracker/test/location/LocationTests.java
+++ b/android/app/src/androidTest/java/edu/berkeley/eecs/cfc_tracker/test/location/LocationTests.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import edu.berkeley.eecs.cfc_tracker.BootReceiver;
 import edu.berkeley.eecs.cfc_tracker.MainActivity;
 import edu.berkeley.eecs.cfc_tracker.R;
+import edu.berkeley.eecs.cfc_tracker.location.TripDiaryStateMachineIntentService;
 import edu.berkeley.eecs.cfc_tracker.location.TripDiaryStateMachineReceiver;
 import edu.berkeley.eecs.cfc_tracker.location.actions.ActivityRecognitionActions;
 import edu.berkeley.eecs.cfc_tracker.location.actions.GeofenceActions;
@@ -257,7 +258,7 @@ public class LocationTests extends ActivityInstrumentationTestCase2<MainActivity
 
     public void verifyTDSMState(int expectedStateId) {
         // Before we get the broadcast, the state should be "START"
-        String currState = TripDiaryStateMachineReceiver.getState(appCtxt);
+        String currState = TripDiaryStateMachineIntentService.getState(appCtxt);
         String expectedState = null;
         if (expectedStateId != -1) {
             expectedState = appCtxt.getString(expectedStateId);

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -96,7 +96,12 @@
 		    android:enabled="true" 
 		    android:exported="false">
 		</service>
-		<service 
+        <service
+            android:name="edu.berkeley.eecs.cfc_tracker.location.TripDiaryStateMachineIntentService"
+            android:enabled="true"
+            android:exported="false">
+        </service>
+        <service
 		    android:name="edu.berkeley.eecs.cfc_tracker.location.GeofenceExitIntentService"
 		    android:enabled="true" 
 		    android:exported="false">

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineIntentService.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineIntentService.java
@@ -1,0 +1,315 @@
+package edu.berkeley.eecs.cfc_tracker.location;
+
+import android.app.IntentService;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.preference.PreferenceManager;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.api.Batch;
+import com.google.android.gms.common.api.BatchResult;
+import com.google.android.gms.common.api.BatchResultToken;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.common.api.ResultCallback;
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.location.ActivityRecognition;
+import com.google.android.gms.location.LocationServices;
+
+import java.security.Provider;
+import java.util.LinkedList;
+import java.util.List;
+
+import edu.berkeley.eecs.cfc_tracker.NotificationHelper;
+import edu.berkeley.eecs.cfc_tracker.R;
+import edu.berkeley.eecs.cfc_tracker.location.actions.ActivityRecognitionActions;
+import edu.berkeley.eecs.cfc_tracker.location.actions.GeofenceActions;
+import edu.berkeley.eecs.cfc_tracker.location.actions.LocationTrackingActions;
+import edu.berkeley.eecs.cfc_tracker.log.Log;
+import edu.berkeley.eecs.cfc_tracker.usercache.UserCacheFactory;
+import edu.berkeley.eecs.cfc_tracker.wrapper.Transition;
+
+/**
+ * Created by shankari on 9/12/15.
+ */
+
+public class TripDiaryStateMachineIntentService extends IntentService implements
+        GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener {
+    public static String TAG = "TripDiaryStateMachineService";
+
+    private static String CURR_STATE_KEY = "TripDiaryCurrState";
+
+    private static int STATE_IN_NUMBERS = 78283;
+
+    /*
+     * Unfortunately, due to the structure of the google API client, with callbacks
+     * and everything, we are unable to do handle the intent statelessly. For example,
+     * when the client is connected, the onConnected() method is invoked asynchronously
+     * with a service specific connection hint. We have to make further calls
+     * (to get the current location, to register a geofence) after we are connected,
+     * using the client. But there is no way to pass in a reference to the client or
+     * to the current state or to the intent action. So all of those need to be stored
+     * in instance variables.
+    */
+
+    private GoogleApiClient mApiClient = null;
+    private String mCurrState = null;
+    private String mTransition = null;
+    private SharedPreferences mPrefs = null;
+
+    public TripDiaryStateMachineIntentService() {
+        super(TAG);
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        mTransition = intent.getAction();
+        mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
+        mCurrState = mPrefs.getString(CURR_STATE_KEY, this.getString(R.string.state_start));
+        Log.d(this, TAG, "after reading from the prefs, the current state is "+mCurrState);
+        UserCacheFactory.getUserCache(this).putMessage(R.string.key_usercache_transition,
+                new Transition(mCurrState, mTransition));
+
+        // We create this here because for the activity lifecycle, we are supposed to
+        // create the client in create, connect in start and disconnect in stop.
+        // so the equivalent for us is to create in the constructor,
+        mApiClient = new GoogleApiClient.Builder(this)
+                .addConnectionCallbacks(this)
+                .addOnConnectionFailedListener(this)
+                .addApi(LocationServices.API)
+                .addApi(ActivityRecognition.API)
+                .build();
+
+        // And then connect to the client. All subsequent processing will be in the onConnected
+        // method
+        // TODO: Also figure out whether it is best to create it here or in the constructor.
+        // If it in the constructor, where do we get the context from?
+        mApiClient.connect();
+    }
+
+    @Override
+    public void onConnected(Bundle connectionHint) {
+        Log.d(this, TAG, "TripDiaryStateMachineReceiver onConnected("+connectionHint+") called");
+        handleAction(this, mApiClient, mCurrState, mTransition);
+
+        // Note that it does NOT work to disconnect from here because the actions in the state
+        // might happen asynchronously, and we disconnect too early, then the async callbacks
+        // are never invoked. In particular, anything called from the "main/UI" thread, such as
+        // the geofence creation, will FAIL if not invoked asynchronously (i.e. if await() is called).
+        // It is the responsibility of the state handler to disconnect correctly.
+        // If the state handler does not disconnect properly, the state machine will fail because
+        // onConnect() is not invoked when connect() is invoked on an already connected client
+        // TODO: This lead to missed messages if we receive a message while an async operation is ongoing!
+        // Should really check isConnected() and handle it!
+        // mApiClient.disconnect();
+    }
+
+    public static String getState(Context ctxt) {
+        SharedPreferences sPrefs = PreferenceManager.getDefaultSharedPreferences(ctxt);
+        return sPrefs.getString(CURR_STATE_KEY, ctxt.getString(R.string.state_start));
+    }
+
+    public void setNewState(String newState) {
+        Log.d(this, TAG, "newState after handling action is "+newState);
+        SharedPreferences.Editor prefsEditor =
+                PreferenceManager.getDefaultSharedPreferences(this).edit();
+        prefsEditor.putString(CURR_STATE_KEY, newState);
+        prefsEditor.apply();
+        Log.d(this, TAG, "newState saved in prefManager is "+
+                PreferenceManager.getDefaultSharedPreferences(this).getString(
+                        CURR_STATE_KEY, "not found"));
+    }
+
+    @Override
+    public void onConnectionSuspended(int cause) {
+        String causeStr = "unknown";
+        if (cause == GoogleApiClient.ConnectionCallbacks.CAUSE_NETWORK_LOST) {
+            causeStr = "network lost";
+        } else if (cause == GoogleApiClient.ConnectionCallbacks.CAUSE_SERVICE_DISCONNECTED) {
+            causeStr = "network disconnected";
+        }
+        NotificationHelper.createNotification(this, STATE_IN_NUMBERS,
+                "google API client connection suspended"+causeStr);
+    }
+
+    @Override
+    public void onConnectionFailed(ConnectionResult cr) {
+        NotificationHelper.createNotification(this, STATE_IN_NUMBERS,
+                "google API client connection failed"+cr.toString());
+
+    }
+
+    /*
+     * Handles the transition based on the current state.
+     * Assumes that the API client is already connected.
+     * TODO: It looks like the various actions are actually pretty similar - they invoke a
+     * method on the API and then wait for a callback. It seems like it should be possible
+     * to write a generic action that takes the google API call and the broadcast intent
+     * as parameters, makes the call, and issues the broadcast in the callback
+     */
+    private void handleAction(Context ctxt, GoogleApiClient apiClient, String currState, String actionString) {
+        Log.d(this, TAG, "TripDiaryStateMachineReceiver handleAction("+currState+", "+actionString+") called");
+        assert(currState != null);
+        // The current state is stored in the shared preferences, so on reboot, for example, we would
+        // store that we are in ongoing_trip, but no listeners would be registered. We can have
+        // the broadcast receiver generate an initialize transition, but the states other than
+        // start don't handle initialize. So if we get an initialize, we manually call the start method.
+        // This does not cover the case in which we get an initialize transition without a reboot, when
+        // an earlier geofence or tracking might well be present.
+        // TODO: Figure out how best to handle this and handle it. Options are:
+        // - have a set state which allows the broadcast code and the test code to set the state to start
+        // when restarting
+        // - have initialize function as a reset, which stops any current stuff and starts the new one
+        if (actionString.equals(ctxt.getString(R.string.transition_initialize))) {
+            handleStart(ctxt, apiClient, actionString);
+        } else if (currState.equals(ctxt.getString(R.string.state_start))) {
+            handleStart(ctxt, apiClient, actionString);
+        } else if (currState.equals(ctxt.getString(R.string.state_waiting_for_trip_start))) {
+            handleTripStart(ctxt, apiClient, actionString);
+        } else if (currState.equals(ctxt.getString(R.string.state_ongoing_trip))) {
+            handleTripEnd(ctxt, apiClient, actionString);
+        }
+    }
+
+    private void handleStart(Context ctxt, GoogleApiClient apiClient, String actionString) {
+        Log.d(this, TAG, "TripDiaryStateMachineReceiver handleStarted(" + actionString + ") called");
+        // Get current location
+        if (actionString.equals(ctxt.getString(R.string.transition_initialize))) {
+            final Context fCtxt = ctxt;
+            com.google.android.gms.common.api.PendingResult<Status> createGeofenceResult =
+                    new GeofenceActions(ctxt, apiClient).create();
+            if (createGeofenceResult != null) {
+                createGeofenceResult.setResultCallback(new ResultCallback<Status>() {
+                    @Override
+                    public void onResult(Status status) {
+                        String newState = fCtxt.getString(R.string.state_waiting_for_trip_start);
+                        if (status.isSuccess()) {
+                            setNewState(newState);
+                            NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
+                                    "Success moving to " + newState);
+                        } else {
+                            NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
+                                    "Failed moving to " + newState);
+                        }
+                        mApiClient.disconnect();
+                    }
+                });
+            }
+        }
+    }
+
+    public void handleTripStart(Context ctxt, GoogleApiClient apiClient, String actionString) {
+        Log.d(this, TAG, "TripDiaryStateMachineReceiver handleTripStart(" + actionString + ") called");
+        if (actionString.equals(ctxt.getString(R.string.transition_exited_geofence))) {
+            // Delete geofence
+            final List<BatchResultToken<Status>> tokenList = new LinkedList<BatchResultToken<Status>>();
+            Batch.Builder resultBarrier = new Batch.Builder(apiClient);
+            tokenList.add(resultBarrier.add(new GeofenceActions(ctxt, apiClient).remove()));
+            tokenList.add(resultBarrier.add(new LocationTrackingActions(ctxt, apiClient).start()));
+            tokenList.add(resultBarrier.add(new ActivityRecognitionActions(ctxt, apiClient).start()));
+            // TODO: How to pass in the token list?
+            // Also, the callback is currently the same for all of them, but could potentially be
+            // different in the future once we add in failure handling because we may want to do
+            // different things based on the different failure cases. If we don't do that, we should
+            // refactor the callback to a common class. and then we need to pass in the token list to it
+            // since it can't use the final variable
+            final Context fCtxt = ctxt;
+            resultBarrier.build().setResultCallback(new ResultCallback<BatchResult>() {
+                @Override
+                public void onResult(BatchResult batchResult) {
+                    String newState = fCtxt.getString(R.string.state_ongoing_trip);
+                    if (batchResult.getStatus().isSuccess()) {
+                        setNewState(newState);
+                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
+                                "Success moving to "+newState);
+                    } else {
+                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
+                                "Failed moving to "+newState+" failed");
+                    }
+                    mApiClient.disconnect();
+                }
+            });
+        }
+        if(actionString.equals(ctxt.getString(R.string.transition_stop_tracking))) {
+            // Delete geofence
+            final List<BatchResultToken<Status>> tokenList = new LinkedList<BatchResultToken<Status>>();
+            Batch.Builder resultBarrier = new Batch.Builder(apiClient);
+            tokenList.add(resultBarrier.add(new GeofenceActions(ctxt, apiClient).remove()));
+            final Context fCtxt = ctxt;
+            resultBarrier.build().setResultCallback(new ResultCallback<BatchResult>() {
+                @Override
+                public void onResult(BatchResult batchResult) {
+                    String newState = fCtxt.getString(R.string.state_start);
+                    if (batchResult.getStatus().isSuccess()) {
+                        setNewState(newState);
+                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
+                                "Success moving to "+newState);
+                    } else {
+                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
+                                "Failed moving to "+newState);
+                    }
+                    mApiClient.disconnect();
+                }
+            });
+        }
+    }
+
+    public void handleTripEnd(Context ctxt, GoogleApiClient apiClient, String actionString) {
+        Log.d(this, TAG, "TripDiaryStateMachineReceiver handleTripEnd(" + actionString + ") called");
+        if (actionString.equals(ctxt.getString(R.string.transition_stopped_moving))) {
+            // Stopping location tracking
+            final List<BatchResultToken<Status>> tokenList = new LinkedList<BatchResultToken<Status>>();
+            Batch.Builder resultBarrier = new Batch.Builder(apiClient);
+            tokenList.add(resultBarrier.add(new LocationTrackingActions(ctxt, apiClient).stop()));
+            tokenList.add(resultBarrier.add(new ActivityRecognitionActions(ctxt, apiClient).stop()));
+            // TODO: This action can return null, and is the only one that can.
+            // Should we refactor to simplify the code? Throw an exception instead?
+            com.google.android.gms.common.api.PendingResult<Status> createGeofenceResult =
+                    new GeofenceActions(ctxt, apiClient).create();
+            if (createGeofenceResult != null) {
+                tokenList.add(resultBarrier.add(createGeofenceResult));
+            }
+            final Context fCtxt = ctxt;
+            resultBarrier.build().setResultCallback(new ResultCallback<BatchResult>() {
+                @Override
+                public void onResult(BatchResult batchResult) {
+                    String newState = fCtxt.getString(R.string.state_waiting_for_trip_start);
+                    if (batchResult.getStatus().isSuccess()) {
+                        setNewState(newState);
+                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
+                                "Success moving to "+newState);
+                    } else {
+                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
+                                "Failed moving to "+newState);
+                    }
+                    mApiClient.disconnect();
+                }
+            });
+        }
+
+        if (actionString.equals(ctxt.getString(R.string.transition_stop_tracking))) {
+            final List<BatchResultToken<Status>> tokenList = new LinkedList<BatchResultToken<Status>>();
+            Batch.Builder resultBarrier = new Batch.Builder(apiClient);
+            tokenList.add(resultBarrier.add(new LocationTrackingActions(ctxt, apiClient).stop()));
+            tokenList.add(resultBarrier.add(new ActivityRecognitionActions(ctxt, apiClient).stop()));
+            final Context fCtxt = ctxt;
+            resultBarrier.build().setResultCallback(new ResultCallback<BatchResult>() {
+                @Override
+                public void onResult(BatchResult batchResult) {
+                    String newState = fCtxt.getString(R.string.state_start);
+                    if (batchResult.getStatus().isSuccess()) {
+                        setNewState(newState);
+                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
+                                "Success moving to "+newState);
+                    } else {
+                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
+                                "Failed moving to "+newState);
+                    }
+                    mApiClient.disconnect();
+                }
+            });
+        }
+    }
+}

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineReceiver.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineReceiver.java
@@ -4,60 +4,33 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.Bundle;
 import android.preference.PreferenceManager;
-import edu.berkeley.eecs.cfc_tracker.log.Log;
-
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.api.Batch;
-import com.google.android.gms.common.api.BatchResult;
-import com.google.android.gms.common.api.BatchResultToken;
-import com.google.android.gms.common.api.GoogleApiClient;
-import com.google.android.gms.common.api.GoogleApiClient.ConnectionCallbacks;
-import com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListener;
-import com.google.android.gms.common.api.ResultCallback;
-import com.google.android.gms.common.api.Status;
-import com.google.android.gms.location.ActivityRecognition;
-import com.google.android.gms.location.LocationServices;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Set;
 
-import edu.berkeley.eecs.cfc_tracker.NotificationHelper;
 import edu.berkeley.eecs.cfc_tracker.R;
-import edu.berkeley.eecs.cfc_tracker.location.actions.ActivityRecognitionActions;
-import edu.berkeley.eecs.cfc_tracker.location.actions.GeofenceActions;
-import edu.berkeley.eecs.cfc_tracker.location.actions.LocationTrackingActions;
-import edu.berkeley.eecs.cfc_tracker.usercache.UserCacheFactory;
-import edu.berkeley.eecs.cfc_tracker.wrapper.Transition;
+import edu.berkeley.eecs.cfc_tracker.log.Log;
 
-public class TripDiaryStateMachineReceiver extends BroadcastReceiver
-	implements ConnectionCallbacks, OnConnectionFailedListener {
+/*
+ * The BroadcastReceiver is really lightweight because it is considered to be inactive once it
+ * returns from onReceive. Most of our real work happens after the google API client is connected,
+ * which is an async call with a callback. It looks like the inactive process can be killed even
+ * when processing the callback.
+ * http://developer.android.com/reference/android/content/BroadcastReceiver.html#ReceiverLifecycle
+ * https://github.com/e-mission/e-mission-data-collection/issues/36
+ *
+ * So most of the real work is in the associated @class TripDiaryStateMachineIntentService
+ */
+
+public class TripDiaryStateMachineReceiver extends BroadcastReceiver {
 
 	public static Set<String> validTransitions = null;
-    private static int STATE_IN_NUMBERS = 78283;
-
 	private static String TAG = "TripDiaryStateMachineReceiver";
-	private static String CURR_STATE_KEY = "TripDiaryCurrState";
-	
-	/*
-	 * Unfortunately, due to the structure of the google API client, with callbacks
-	 * and everything, we are unable to do handle the intent statelessly. For example,
-	 * when the client is connected, the onConnected() method is invoked asynchronously
-	 * with a service specific connection hint. We have to make further calls 
-	 * (to get the current location, to register a geofence) after we are connected,
-	 * using the client. But there is no way to pass in a reference to the client or
-	 * to the current state or to the intent action. So all of those need to be stored
-	 * in instance variables.
-	 */
-	private GoogleApiClient mApiClient = null;
-	private String mCurrState = null;
-	private String mTransition = null;
-	private SharedPreferences mPrefs = null;
-	private Context mContext = null;
+
+    // Can remove this if we can remove the constructor with the Context argument.
+    private static String CURR_STATE_KEY = "TripDiaryCurrState";
 
     public TripDiaryStateMachineReceiver() {
         // The automatically created receiver needs a default constructor
@@ -65,7 +38,11 @@ public class TripDiaryStateMachineReceiver extends BroadcastReceiver
     }
 
 	public TripDiaryStateMachineReceiver(Context context) {
-		Log.i(mContext, TAG, "TripDiaryStateMachineReceiver constructor called");
+		android.util.Log.i(TAG, "TripDiaryStateMachineReceiver constructor called");
+
+        // Why do we need to put the CURR_STATE_KEY to null every time the receiver is created?
+        // Oh wait, is this the call from the activity?
+        // Need to investigate and unify
         SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(context).edit();
         editor.putString(CURR_STATE_KEY, null);
         editor.apply();
@@ -73,10 +50,8 @@ public class TripDiaryStateMachineReceiver extends BroadcastReceiver
 
 	@Override
 	public void onReceive(Context context, Intent intent) {
-		Log.i(mContext, TAG, "TripDiaryStateMachineReciever onReceive("+context+", "+intent+") called");
-		// Populate all the instance variables to determine the transition
-        mContext = context;
-		mTransition = intent.getAction();
+        Log.i(context, TAG, "TripDiaryStateMachineReciever onReceive(" + context + ", " + intent + ") called");
+
         // Next two calls copied over from the constructor, figure out if this is the best place to
         // put them
         validTransitions = new HashSet<String>(Arrays.asList(new String[]{
@@ -86,244 +61,14 @@ public class TripDiaryStateMachineReceiver extends BroadcastReceiver
                 context.getString(R.string.transition_stop_tracking)
         }));
 
-        // We create this here because for the activity lifecycle, we are supposed to
-        // create the client in create, connect in start and disconnect in stop.
-        // so the equivalent for us is to create in the constructor,
-        mApiClient = new GoogleApiClient.Builder(context)
-                .addConnectionCallbacks(this)
-                .addOnConnectionFailedListener(this)
-                .addApi(LocationServices.API)
-                .addApi(ActivityRecognition.API)
-                .build();
-
-        if (!validTransitions.contains(mTransition)) {
-        	Log.e(mContext, TAG, "Received unknown action "+intent.getAction()+" ignoring");
-        	return;
+        if (!validTransitions.contains(intent.getAction())) {
+            Log.e(context, TAG, "Received unknown action "+intent.getAction()+" ignoring");
+            return;
         }
-        mPrefs = PreferenceManager.getDefaultSharedPreferences(context);
-        mCurrState = mPrefs.getString(CURR_STATE_KEY, context.getString(R.string.state_start));
-        Log.d(mContext, TAG, "after reading from the prefs, the current state is "+mCurrState);
-        UserCacheFactory.getUserCache(mContext).putMessage(R.string.key_usercache_transition,
-                new Transition(mCurrState, mTransition));
-        // And then connect to the client. All subsequent processing will be in the onConnected
-        // method
-        // TODO: Also figure out whether it is best to create it here or in the constructor.
-        // If it in the constructor, where do we get the context from?
-		mApiClient.connect();
-	}
+
+        Intent serviceStartIntent = new Intent(context, TripDiaryStateMachineIntentService.class);
+        serviceStartIntent.setAction(intent.getAction());
+        context.startService(serviceStartIntent);
+    }
 	
-	@Override
-	public void onConnected(Bundle connectionHint) {
-		Log.d(mContext, TAG, "TripDiaryStateMachineReceiver onConnected("+connectionHint+") called");
-		handleAction(mContext, mApiClient, mCurrState, mTransition);
-
-		// Note that it does NOT work to disconnect from here because the actions in the state
-        // might happen asynchronously, and we disconnect too early, then the async callbacks
-        // are never invoked. In particular, anything called from the "main/UI" thread, such as
-        // the geofence creation, will FAIL if not invoked asynchronously (i.e. if await() is called).
-        // It is the responsibility of the state handler to disconnect correctly.
-        // If the state handler does not disconnect properly, the state machine will fail because
-        // onConnect() is not invoked when connect() is invoked on an already connected client
-        // TODO: This lead to missed messages if we receive a message while an async operation is ongoing!
-        // Should really check isConnected() and handle it!
-		// mApiClient.disconnect();
-	}
-
-    public static String getState(Context ctxt) {
-        SharedPreferences sPrefs = PreferenceManager.getDefaultSharedPreferences(ctxt);
-        return sPrefs.getString(CURR_STATE_KEY, ctxt.getString(R.string.state_start));
-    }
-
-    public void setNewState(String newState) {
-        Log.d(mContext, TAG, "newState after handling action is "+newState);
-        SharedPreferences.Editor prefsEditor =
-                PreferenceManager.getDefaultSharedPreferences(mContext).edit();
-        prefsEditor.putString(CURR_STATE_KEY, newState);
-        prefsEditor.apply();
-        Log.d(mContext, TAG, "newState saved in prefManager is "+
-            PreferenceManager.getDefaultSharedPreferences(mContext).getString(
-                    CURR_STATE_KEY, "not found"));
-    }
-
-	@Override
-	public void onConnectionSuspended(int arg0) {
-		// TODO Auto-generated method stub
-	}
-
-	@Override
-	public void onConnectionFailed(ConnectionResult arg0) {
-		// TODO Auto-generated method stub
-		
-	}
-	
-	/*
-	 * Handles the transition based on the current state.
-	 * Assumes that the API client is already connected.
-	 * TODO: It looks like the various actions are actually pretty similar - they invoke a
-	 * method on the API and then wait for a callback. It seems like it should be possible
-	 * to write a generic action that takes the google API call and the broadcast intent
-	 * as parameters, makes the call, and issues the broadcast in the callback
-	 */
-	private void handleAction(Context ctxt, GoogleApiClient apiClient, String currState, String actionString) {
-		Log.d(mContext, TAG, "TripDiaryStateMachineReceiver handleAction("+currState+", "+actionString+") called");
-		assert(currState != null);
-        // The current state is stored in the shared preferences, so on reboot, for example, we would
-        // store that we are in ongoing_trip, but no listeners would be registered. We can have
-        // the broadcast receiver generate an initialize transition, but the states other than
-        // start don't handle initialize. So if we get an initialize, we manually call the start method.
-        // This does not cover the case in which we get an initialize transition without a reboot, when
-        // an earlier geofence or tracking might well be present.
-        // TODO: Figure out how best to handle this and handle it. Options are:
-        // - have a set state which allows the broadcast code and the test code to set the state to start
-        // when restarting
-        // - have initialize function as a reset, which stops any current stuff and starts the new one
-        if (actionString.equals(ctxt.getString(R.string.transition_initialize))) {
-            handleStart(ctxt, apiClient, actionString);
-        } else if (currState.equals(ctxt.getString(R.string.state_start))) {
-			handleStart(ctxt, apiClient, actionString);
-        } else if (currState.equals(ctxt.getString(R.string.state_waiting_for_trip_start))) {
-            handleTripStart(ctxt, apiClient, actionString);
-        } else if (currState.equals(ctxt.getString(R.string.state_ongoing_trip))) {
-            handleTripEnd(ctxt, apiClient, actionString);
-        }
-	}
-	
-	private void handleStart(Context ctxt, GoogleApiClient apiClient, String actionString) {
-		Log.d(mContext, TAG, "TripDiaryStateMachineReceiver handleStarted("+actionString+") called");
-		// Get current location
-		if (actionString.equals(ctxt.getString(R.string.transition_initialize))) {
-            final Context fCtxt = ctxt;
-            com.google.android.gms.common.api.PendingResult<Status> createGeofenceResult =
-            new GeofenceActions(ctxt, apiClient).create();
-            if (createGeofenceResult != null) {
-                createGeofenceResult.setResultCallback(new ResultCallback<Status>() {
-                    @Override
-                    public void onResult(Status status) {
-                        String newState = fCtxt.getString(R.string.state_waiting_for_trip_start);
-                        if (status.isSuccess()) {
-                            setNewState(newState);
-                            NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
-                                    "Success moving to " + newState);
-                        } else {
-                            NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
-                                    "Failed moving to " + newState);
-                        }
-                        mApiClient.disconnect();
-                    }
-                });
-            }
-        }
-    }
-
-    public void handleTripStart(Context ctxt, GoogleApiClient apiClient, String actionString) {
-        Log.d(mContext, TAG, "TripDiaryStateMachineReceiver handleTripStart("+actionString+") called");
-        if (actionString.equals(ctxt.getString(R.string.transition_exited_geofence))) {
-            // Delete geofence
-            final List<BatchResultToken<Status>> tokenList = new LinkedList<BatchResultToken<Status>>();
-            Batch.Builder resultBarrier = new Batch.Builder(apiClient);
-            tokenList.add(resultBarrier.add(new GeofenceActions(ctxt, apiClient).remove()));
-            tokenList.add(resultBarrier.add(new LocationTrackingActions(ctxt, apiClient).start()));
-            tokenList.add(resultBarrier.add(new ActivityRecognitionActions(ctxt, apiClient).start()));
-            // TODO: How to pass in the token list?
-            // Also, the callback is currently the same for all of them, but could potentially be
-            // different in the future once we add in failure handling because we may want to do
-            // different things based on the different failure cases. If we don't do that, we should
-            // refactor the callback to a common class. and then we need to pass in the token list to it
-            // since it can't use the final variable
-            final Context fCtxt = ctxt;
-            resultBarrier.build().setResultCallback(new ResultCallback<BatchResult>() {
-                @Override
-                public void onResult(BatchResult batchResult) {
-                    String newState = fCtxt.getString(R.string.state_ongoing_trip);
-                    if (batchResult.getStatus().isSuccess()) {
-                        setNewState(newState);
-                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
-                                "Success moving to "+newState);
-                    } else {
-                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
-                                "Failed moving to "+newState+" failed");
-                    }
-                    mApiClient.disconnect();
-                }
-            });
-        }
-        if(actionString.equals(ctxt.getString(R.string.transition_stop_tracking))) {
-            // Delete geofence
-            final List<BatchResultToken<Status>> tokenList = new LinkedList<BatchResultToken<Status>>();
-            Batch.Builder resultBarrier = new Batch.Builder(apiClient);
-            tokenList.add(resultBarrier.add(new GeofenceActions(ctxt, apiClient).remove()));
-            final Context fCtxt = ctxt;
-            resultBarrier.build().setResultCallback(new ResultCallback<BatchResult>() {
-                @Override
-                public void onResult(BatchResult batchResult) {
-                    String newState = fCtxt.getString(R.string.state_start);
-                    if (batchResult.getStatus().isSuccess()) {
-                        setNewState(newState);
-                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
-                                "Success moving to "+newState);
-                    } else {
-                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
-                                "Failed moving to "+newState);
-                    }
-                    mApiClient.disconnect();
-                }
-            });
-        }
-    }
-
-    public void handleTripEnd(Context ctxt, GoogleApiClient apiClient, String actionString) {
-        Log.d(mContext, TAG, "TripDiaryStateMachineReceiver handleTripEnd(" + actionString + ") called");
-        if (actionString.equals(ctxt.getString(R.string.transition_stopped_moving))) {
-            // Stopping location tracking
-            final List<BatchResultToken<Status>> tokenList = new LinkedList<BatchResultToken<Status>>();
-            Batch.Builder resultBarrier = new Batch.Builder(apiClient);
-            tokenList.add(resultBarrier.add(new LocationTrackingActions(ctxt, apiClient).stop()));
-            tokenList.add(resultBarrier.add(new ActivityRecognitionActions(ctxt, apiClient).stop()));
-            // TODO: This action can return null, and is the only one that can.
-            // Should we refactor to simplify the code? Throw an exception instead?
-            com.google.android.gms.common.api.PendingResult<Status> createGeofenceResult =
-                    new GeofenceActions(ctxt, apiClient).create();
-            if (createGeofenceResult != null) {
-                tokenList.add(resultBarrier.add(createGeofenceResult));
-            }
-            final Context fCtxt = ctxt;
-            resultBarrier.build().setResultCallback(new ResultCallback<BatchResult>() {
-                @Override
-                public void onResult(BatchResult batchResult) {
-                    String newState = fCtxt.getString(R.string.state_waiting_for_trip_start);
-                    if (batchResult.getStatus().isSuccess()) {
-                        setNewState(newState);
-                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
-                                "Success moving to "+newState);
-                    } else {
-                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
-                                "Failed moving to "+newState);
-                    }
-                    mApiClient.disconnect();
-                }
-            });
-        }
-        if (actionString.equals(ctxt.getString(R.string.transition_stop_tracking))) {
-            final List<BatchResultToken<Status>> tokenList = new LinkedList<BatchResultToken<Status>>();
-            Batch.Builder resultBarrier = new Batch.Builder(apiClient);
-            tokenList.add(resultBarrier.add(new LocationTrackingActions(ctxt, apiClient).stop()));
-            tokenList.add(resultBarrier.add(new ActivityRecognitionActions(ctxt, apiClient).stop()));
-            final Context fCtxt = ctxt;
-            resultBarrier.build().setResultCallback(new ResultCallback<BatchResult>() {
-                @Override
-                public void onResult(BatchResult batchResult) {
-                    String newState = fCtxt.getString(R.string.state_start);
-                    if (batchResult.getStatus().isSuccess()) {
-                        setNewState(newState);
-                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
-                                "Success moving to "+newState);
-                    } else {
-                        NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
-                                "Failed moving to "+newState);
-                    }
-                    mApiClient.disconnect();
-                }
-            });
-        }
-    }
 }

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/smap/AddDataAdapter.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/smap/AddDataAdapter.java
@@ -3,6 +3,22 @@
  */
 package edu.berkeley.eecs.cfc_tracker.smap;
 
+import android.accounts.Account;
+import android.content.AbstractThreadedSyncAdapter;
+import android.content.ContentProviderClient;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SyncResult;
+import android.net.http.AndroidHttpClient;
+import android.os.Bundle;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -13,31 +29,13 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.UUID;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.StringEntity;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import edu.berkeley.eecs.cfc_tracker.CommunicationHelper;
 import edu.berkeley.eecs.cfc_tracker.ConnectionSettings;
 import edu.berkeley.eecs.cfc_tracker.Constants;
 import edu.berkeley.eecs.cfc_tracker.R;
 import edu.berkeley.eecs.cfc_tracker.auth.GoogleAccountManagerAuth;
 import edu.berkeley.eecs.cfc_tracker.auth.UserProfile;
-
-import android.accounts.Account;
-import android.content.AbstractThreadedSyncAdapter;
-import android.content.ContentProviderClient;
-import android.content.Context;
-import android.content.Intent;
-import android.content.SyncResult;
-import android.net.http.AndroidHttpClient;
-import android.os.Bundle;
-
-import edu.berkeley.eecs.cfc_tracker.location.TripDiaryStateMachineReceiver;
-import edu.berkeley.eecs.cfc_tracker.location.actions.GeofenceActions;
+import edu.berkeley.eecs.cfc_tracker.location.TripDiaryStateMachineIntentService;
 import edu.berkeley.eecs.cfc_tracker.log.Log;
 import edu.berkeley.eecs.cfc_tracker.usercache.BuiltinUserCache;
 import edu.berkeley.eecs.cfc_tracker.usercache.UserCache;
@@ -170,9 +168,9 @@ public class AddDataAdapter extends AbstractThreadedSyncAdapter {
         /*
          * Check for being in geofence if in waiting_for_trip_state.
          */
-        if (TripDiaryStateMachineReceiver.getState(mContext).equals(mContext.getString(R.string.state_start))) {
+        if (TripDiaryStateMachineIntentService.getState(mContext).equals(mContext.getString(R.string.state_start))) {
             mContext.sendBroadcast(new Intent(mContext.getString(R.string.transition_initialize)));
-        } else if (TripDiaryStateMachineReceiver.getState(mContext).equals(
+        } else if (TripDiaryStateMachineIntentService.getState(mContext).equals(
                 mContext.getString(R.string.state_waiting_for_trip_start))) {
             // check in geofence
         }

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/wrapper/Metadata.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/wrapper/Metadata.java
@@ -3,6 +3,7 @@ package edu.berkeley.eecs.cfc_tracker.wrapper;
 /**
  * Created by shankari on 7/5/15.
  */
+
 public class Metadata {
     public long getWrite_ts() {
         return write_ts;
@@ -44,8 +45,14 @@ public class Metadata {
         this.plugin = plugin;
     }
 
+    public void setTimeZone(String timeZone) { this.time_zone = timeZone; }
+
+    public String getTimeZone() { return time_zone; }
+
+
     private long write_ts;
     private long read_ts;
+    private String time_zone;
     private String type;
     private String key;
     private String plugin;

--- a/android/app/src/main/res/values/usercache_keys.xml
+++ b/android/app/src/main/res/values/usercache_keys.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="key.usercache.location">background/location</string>
     <string name="key.usercache.filtered_location">background/filtered_location</string>
-    <string name="key.usercache.activity">background/activity</string>
+    <string name="key.usercache.activity">background/motion_activity</string>
     <string name="key.usercache.accelerometer">background/accelerometer</string>
     <string name="key.usercache.battery">background/battery</string>
     <string name="key.usercache.config_sensors">config/sensors</string>


### PR DESCRIPTION
…machine in a separate service

It looks like once the broadcast receiver is marked as inactive (after
returning from onReceive) even callbacks can be terminated in the middle.

This launches a service to do the bulk of the work and avoid early termination.

Testing done: LocationTests run successfully. They don't actually return a pass state because the test conditions need to be modified to match the new trip end detection, but the logs indicate that the services are all started correctly.