### PR TITLE
Change the TripDiary manipulation from an intent service to a service

### DIFF
--- a/android/app/src/androidTest/java/edu/berkeley/eecs/cfc_tracker/test/location/LocationTests.java
+++ b/android/app/src/androidTest/java/edu/berkeley/eecs/cfc_tracker/test/location/LocationTests.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import edu.berkeley.eecs.cfc_tracker.BootReceiver;
 import edu.berkeley.eecs.cfc_tracker.MainActivity;
 import edu.berkeley.eecs.cfc_tracker.R;
-import edu.berkeley.eecs.cfc_tracker.location.TripDiaryStateMachineIntentService;
+import edu.berkeley.eecs.cfc_tracker.location.TripDiaryStateMachineService;
 import edu.berkeley.eecs.cfc_tracker.location.TripDiaryStateMachineReceiver;
 import edu.berkeley.eecs.cfc_tracker.location.actions.ActivityRecognitionActions;
 import edu.berkeley.eecs.cfc_tracker.location.actions.GeofenceActions;
@@ -258,7 +258,7 @@ public class LocationTests extends ActivityInstrumentationTestCase2<MainActivity
 
     public void verifyTDSMState(int expectedStateId) {
         // Before we get the broadcast, the state should be "START"
-        String currState = TripDiaryStateMachineIntentService.getState(appCtxt);
+        String currState = TripDiaryStateMachineService.getState(appCtxt);
         String expectedState = null;
         if (expectedStateId != -1) {
             expectedState = appCtxt.getString(expectedStateId);

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineReceiver.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineReceiver.java
@@ -66,7 +66,7 @@ public class TripDiaryStateMachineReceiver extends BroadcastReceiver {
             return;
         }
 
-        Intent serviceStartIntent = new Intent(context, TripDiaryStateMachineIntentService.class);
+        Intent serviceStartIntent = new Intent(context, TripDiaryStateMachineService.class);
         serviceStartIntent.setAction(intent.getAction());
         context.startService(serviceStartIntent);
     }

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineService.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineService.java
@@ -35,7 +35,7 @@ import edu.berkeley.eecs.cfc_tracker.wrapper.Transition;
  * Created by shankari on 9/12/15.
  */
 
-public class TripDiaryStateMachineIntentService extends Service implements
+public class TripDiaryStateMachineService extends Service implements
         GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener {
     public static String TAG = "TripDiaryStateMachineService";
 
@@ -59,7 +59,7 @@ public class TripDiaryStateMachineIntentService extends Service implements
     private String mTransition = null;
     private SharedPreferences mPrefs = null;
 
-    public TripDiaryStateMachineIntentService() {
+    public TripDiaryStateMachineService() {
         super();
     }
 

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineService.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/location/TripDiaryStateMachineService.java
@@ -1,6 +1,6 @@
 package edu.berkeley.eecs.cfc_tracker.location;
 
-import android.app.IntentService;
+import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -35,7 +35,7 @@ import edu.berkeley.eecs.cfc_tracker.wrapper.Transition;
  * Created by shankari on 9/12/15.
  */
 
-public class TripDiaryStateMachineIntentService extends IntentService implements
+public class TripDiaryStateMachineIntentService extends Service implements
         GoogleApiClient.ConnectionCallbacks, GoogleApiClient.OnConnectionFailedListener {
     public static String TAG = "TripDiaryStateMachineService";
 
@@ -60,11 +60,26 @@ public class TripDiaryStateMachineIntentService extends IntentService implements
     private SharedPreferences mPrefs = null;
 
     public TripDiaryStateMachineIntentService() {
-        super(TAG);
+        super();
     }
 
     @Override
-    protected void onHandleIntent(Intent intent) {
+    public void onDestroy() {
+        Log.i(this, TAG, "Service destroyed. So long, suckers!");
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent,  int flags, int startId) {
+        Log.d(this, TAG, "service started with flags = "+flags+" startId = "+startId
+                +" action = "+intent.getAction());
+        if (flags == Service.START_FLAG_REDELIVERY) {
+            Log.d(this, TAG, "service restarted! need to check idempotency!");
+        }
         mTransition = intent.getAction();
         mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
         mCurrState = mPrefs.getString(CURR_STATE_KEY, this.getString(R.string.state_start));
@@ -87,6 +102,18 @@ public class TripDiaryStateMachineIntentService extends IntentService implements
         // TODO: Also figure out whether it is best to create it here or in the constructor.
         // If it in the constructor, where do we get the context from?
         mApiClient.connect();
+        /*
+         We are returning with START_REDELIVER_INTENT, so the process will be restarted with the
+         same intent if it is killed. We need to think through the implications of this. If the
+         process was killed before any of the actions were performed, then we are fine. If the
+         process was killed after the actions were performed, then we are in trouble, because the
+         actions are not necessarily idempotent.
+
+         Some of the actions are clearly idempotent. For example, starting the activity recognition
+         API. For example, deleting a geofence. It might be easiest to convert the actions to be
+         idempotent, but that requires some careful work. TODO: Need to think through this carefully.
+         */
+        return START_REDELIVER_INTENT;
     }
 
     @Override
@@ -116,10 +143,11 @@ public class TripDiaryStateMachineIntentService extends IntentService implements
         SharedPreferences.Editor prefsEditor =
                 PreferenceManager.getDefaultSharedPreferences(this).edit();
         prefsEditor.putString(CURR_STATE_KEY, newState);
-        prefsEditor.apply();
+        prefsEditor.commit();
         Log.d(this, TAG, "newState saved in prefManager is "+
                 PreferenceManager.getDefaultSharedPreferences(this).getString(
                         CURR_STATE_KEY, "not found"));
+        stopSelf();
     }
 
     @Override

--- a/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/smap/AddDataAdapter.java
+++ b/android/app/src/main/java/edu/berkeley/eecs/cfc_tracker/smap/AddDataAdapter.java
@@ -35,7 +35,7 @@ import edu.berkeley.eecs.cfc_tracker.Constants;
 import edu.berkeley.eecs.cfc_tracker.R;
 import edu.berkeley.eecs.cfc_tracker.auth.GoogleAccountManagerAuth;
 import edu.berkeley.eecs.cfc_tracker.auth.UserProfile;
-import edu.berkeley.eecs.cfc_tracker.location.TripDiaryStateMachineIntentService;
+import edu.berkeley.eecs.cfc_tracker.location.TripDiaryStateMachineService;
 import edu.berkeley.eecs.cfc_tracker.log.Log;
 import edu.berkeley.eecs.cfc_tracker.usercache.BuiltinUserCache;
 import edu.berkeley.eecs.cfc_tracker.usercache.UserCache;
@@ -168,9 +168,9 @@ public class AddDataAdapter extends AbstractThreadedSyncAdapter {
         /*
          * Check for being in geofence if in waiting_for_trip_state.
          */
-        if (TripDiaryStateMachineIntentService.getState(mContext).equals(mContext.getString(R.string.state_start))) {
+        if (TripDiaryStateMachineService.getState(mContext).equals(mContext.getString(R.string.state_start))) {
             mContext.sendBroadcast(new Intent(mContext.getString(R.string.transition_initialize)));
-        } else if (TripDiaryStateMachineIntentService.getState(mContext).equals(
+        } else if (TripDiaryStateMachineService.getState(mContext).equals(
                 mContext.getString(R.string.state_waiting_for_trip_start))) {
             // check in geofence
         }


### PR DESCRIPTION
While an IntentService is recommended for performing operations in a separate
background thread, it is not a suitable option for us for the following
reasons:
- we are already running in the background since we are invoked from the BroadcastReceiver
- the IntentService calls stopSelf automatically once the intent is handled.
  But this means that async operations, such as the ones to create the geofence
  or to start tracking may return only after the service has already been
  stopped or started.
    - So in order to get the state machine to work properly, we want to wait
      until all operations have finished, and the new state is set to stop the service