### PR TITLE
Make some more important transitions show up in the notification screen

### DIFF
--- a/iOS/CFC_Tracker/CFC_Tracker/AppDelegate.m
+++ b/iOS/CFC_Tracker/CFC_Tracker/AppDelegate.m
@@ -92,8 +92,14 @@ typedef void (^SilentPushCompletionHandler)(UIBackgroundFetchResult);
             [DataUtils pushAndClearData:^(BOOL status) {
                 // We only ever call this with true right now
                 if (status == true) {
+                    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                               @"Returning with fetch result = new data"]
+                                                       showUI:TRUE];
                     _silentPushHandler(UIBackgroundFetchResultNewData);
                 } else {
+                    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                               @"Returning with fetch result = no data"]
+                                                       showUI:TRUE];
                     _silentPushHandler(UIBackgroundFetchResultNoData);
                 }
             }];
@@ -144,6 +150,9 @@ typedef void (^SilentPushCompletionHandler)(UIBackgroundFetchResult);
 - (void)application:(UIApplication *)application
                     didReceiveRemoteNotification:(NSDictionary *)userInfo
                     fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                               @"Received remote push, about to check whether a trip has ended"]
+                                       showUI:TRUE];
     NSLog(@"About to check whether a trip has ended");
     [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName object:CFCTransitionRecievedSilentPush];
     _silentPushHandler = completionHandler;
@@ -182,7 +191,8 @@ typedef void (^SilentPushCompletionHandler)(UIBackgroundFetchResult);
     NSLog(@"performFetchWithCompletionHandler called at %@", [NSDate date]);
     [DataUtils pushAndClearData:^(BOOL status) {
         [LocalNotificationManager addNotification:[NSString stringWithFormat:
-                                                   @"in background fetch, finished pushing entries to the server"]];
+                                                   @"in background fetch, finished pushing entries to the server"]
+                                           showUI:TRUE];
     }];
 }
 

--- a/iOS/CFC_Tracker/CFC_Tracker/DataUtils.m
+++ b/iOS/CFC_Tracker/CFC_Tracker/DataUtils.m
@@ -185,7 +185,8 @@
      * Since we now detect trip end only after the user has been stationary for a while, this should be fine.
      * We need to test this more carefully when we switch to the visit-based tracking.
      */
-    
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                               @"pushAndClearData called"] showUI:TRUE];
     NSArray* locEntriesToPush = [[BuiltinUserCache database] syncPhoneToServer];
     if (locEntriesToPush.count == 0) {
         NSLog(@"No location data to send, returning early");
@@ -272,7 +273,8 @@
                              completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                                  [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                                             @"successfully pushed %ld entries to the server",
-                                                                            (unsigned long)entriesToPush.count]];
+                                                                            (unsigned long)entriesToPush.count]
+                                                                    showUI:TRUE];
                                  // Only delete trips after they have been successfully pushed
                                  if (error == nil) {
                                      [[BuiltinUserCache database] clearEntries:tq];

--- a/iOS/CFC_Tracker/CFC_Tracker/TripDiaryActions.m
+++ b/iOS/CFC_Tracker/CFC_Tracker/TripDiaryActions.m
@@ -100,7 +100,10 @@
         geofenceRegion.notifyOnExit = YES;
         [LocalNotificationManager addNotification:[NSString stringWithFormat:@"BEFORE creating region"]];
         [self printGeofences:manager];
-    
+
+        [LocalNotificationManager addNotification:[NSString
+                                                   stringWithFormat:@"About to start monitoring for region around (%f, %f, %f)", currLoc.coordinate.latitude, currLoc.coordinate.longitude, currLoc.horizontalAccuracy]
+                                           showUI:TRUE];
         [manager startMonitoringForRegion:geofenceRegion];
         [LocalNotificationManager addNotification:[NSString stringWithFormat:@"AFTER creating region"]];
         [self printGeofences:manager];

--- a/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.h
+++ b/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.h
@@ -32,6 +32,8 @@
 #define CFCTransitionTripEnded @"T_TRIP_ENDED"
 #define CFCTransitionForceStopTracking @"T_FORCE_STOP_TRACKING"
 #define CFCTransitionTrackingStopped @"T_TRACKING_STOPPED"
+#define CFCTransitionVisitStarted @"T_VISIT_STARTED"
+#define CFCTransitionVisitEnded @"T_VISIT_ENDED"
 #define CFCTransitionNOP @"T_NOP"
 
 /*

--- a/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.m
+++ b/iOS/CFC_Tracker/CFC_Tracker/TripDiaryStateMachine.m
@@ -198,7 +198,7 @@ static NSString * const kCurrState = @"CURR_STATE";
     [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                @"Received transition %@ in state %@",
                                                transition,
-                                               [TripDiaryStateMachine getStateName:self.currState]]];
+                                               [TripDiaryStateMachine getStateName:self.currState]] showUI:TRUE];
     Transition* transitionWrapper = [Transition new];
     transitionWrapper.currState = [TripDiaryStateMachine getStateName:self.currState];
     transitionWrapper.transition = transition;


### PR DESCRIPTION
We have had intermittent problems with the following functionality:
- remote pushes are not delivered correctly, sometimes just when we need them,
  like when a trip ends. This seems to have become worse after the change to
  store the background location.
- changes are pushed to the server multiple times, in particular, activity
  changes, which are repeated upto 3 or 4 times
```
END 2015-11-27 19:34:19.236686 POST /usercache/put 079e0f1a-c440-3d7c-b0e7-de160f748e35 492.189321041
END 2015-11-27 19:34:19.238078 POST /usercache/put 079e0f1a-c440-3d7c-b0e7-de160f748e35 492.53057313
END 2015-11-27 19:34:19.244905 POST /usercache/put 079e0f1a-c440-3d7c-b0e7-de160f748e35 492.34781599
END 2015-11-27 19:34:19.250641 POST /usercache/put 079e0f1a-c440-3d7c-b0e7-de160f748e35 491.087853909
END 2015-11-27 19:34:19.252719 POST /usercache/put 079e0f1a-c440-3d7c-b0e7-de160f748e35 489.149410963
```
- geofence creation sometimes appears to fail if it happens entirely in the
  background. Right now, this is not an issue with the remote push because it
  waits until the trip has fully ended, but it might be an issue again if we
  return to visits, so let's document pre-emptively.

Let's log all of these to the UI so that we can see them without bringing the
app to the foreground and perturbing the results