### PR TITLE
Change the default location config to be consistent with android

### DIFF
--- a/src/ios/Location/LocationTrackingConfig.m
+++ b/src/ios/Location/LocationTrackingConfig.m
@@ -34,11 +34,11 @@ static LocationTrackingConfig *_instance;
 }
 
 - (double)accuracy {
-    return kCLLocationAccuracyHundredMeters;
+    return kCLLocationAccuracyBest;
 }
 
 - (int)filterDistance {
-    return kHundred_Meters;
+    return kFifty_Meters;
 }
 
 - (int)geofenceRadius {


### PR DESCRIPTION
= High accuracy, slow sampling

However, preliminary results from the data collection show that on iOS, the
sampling rate doesn't really affect the power drain - it is only the accuracy
that does. And if we don't have enough data points, iOS seems to miss some
trips.

So we'll increase the sampling frequency just a teeny little bit. And of
course, we need to investigate this further...