### PR TITLE
Handle upgrades correctly

### DIFF
--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -15,7 +15,8 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.android.gms.location.LocationRequest;
 
-import edu.berkeley.eecs.emission.R;
+import edu.berkeley.eecs.emission.*;
+import edu.berkeley.eecs.emission.BuildConfig;
 import edu.berkeley.eecs.emission.cordova.tracker.location.LocationTrackingConfig;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.Log;
 
@@ -31,7 +32,8 @@ public class DataCollectionPlugin extends CordovaPlugin {
             Log.d(myActivity, TAG, "google play services available, initializing state machine");
             SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(myActivity);
             System.out.println("All preferences are "+sp.getAll());
-            if(!sp.getBoolean(SETUP_COMPLETE_KEY, false)) {
+            int currentCompleteVersion = sp.getInt(SETUP_COMPLETE_KEY, 0);
+            if(currentCompleteVersion != BuildConfig.VERSION_CODE) {
                 Log.d(myActivity, TAG, "Setup not complete, sending initialize");
                 myActivity.sendBroadcast(new Intent(myActivity.getString(R.string.transition_initialize)));
                 SharedPreferences.Editor prefsEditor = sp.edit();
@@ -39,7 +41,7 @@ public class DataCollectionPlugin extends CordovaPlugin {
                 // However, it looks like it doesn't actually work - it looks like the app preferences plugin
                 // saves to local storage by default. Need to debug the app preferences plugin and maybe ask
                 // some questions of the maintainer. For now, setting it here for the first time should be fine.
-                prefsEditor.putBoolean(SETUP_COMPLETE_KEY, true);
+                prefsEditor.putInt(SETUP_COMPLETE_KEY, BuildConfig.VERSION_CODE);
                 prefsEditor.commit();
             } else {
                 Log.d(myActivity, TAG, "Setup complete, skipping initialize");


### PR DESCRIPTION
For a particular version of the app, once we have initialized the state
machine, it will run fine. But when we upgrade, all existing geofences, just
like all notifications, are deleted. But the shared preferences are NOT deleted.

So with the previous implementation, the FSM is initialized on install but not
on upgrade, which means that tracking stops on upgrade.

We fix that by storing the version that was initialized instead, and
reinitializing every time the version changes.