### PR TITLE
Refactor the init code to move from the AppDelegate to plugin init

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -152,6 +152,7 @@
 
     <header-file src="src/ios/BEMDataCollection.h"/>
     <header-file src="src/ios/BEMAppDelegate.h"/>
+    <header-file src="src/ios/BEMRemotePushNotificationHandler.h"/>
     <header-file src="src/ios/Location/DataUtils.h" target-dir="Location"/>
     <header-file src="src/ios/Location/GeofenceActions.h" target-dir="Location"/>
     <header-file src="src/ios/Location/LocationTrackingConfig.h" target-dir="Location"/>
@@ -165,6 +166,7 @@
     <header-file src="src/ios/Wrapper/Transition.h" target-dir="Wrapper"/>
     <source-file src="src/ios/BEMDataCollection.m"/>
     <source-file src="src/ios/BEMAppDelegate.m"/>
+    <source-file src="src/ios/BEMRemotePushNotificationHandler.m"/>
     <source-file src="src/ios/Location/DataUtils.m" target-dir="Location"/>
     <source-file src="src/ios/Location/GeofenceActions.m" target-dir="Location"/>
     <source-file src="src/ios/Location/LocationTrackingConfig.m" target-dir="Location"/>

--- a/src/android/location/ActivityRecognitionChangeIntentService.java
+++ b/src/android/location/ActivityRecognitionChangeIntentService.java
@@ -28,8 +28,8 @@ public class ActivityRecognitionChangeIntentService extends IntentService {
 	@Override
 	protected void onHandleIntent(Intent intent) {
 		Log.d(this, TAG, "FINALLY! Got activity update, intent is "+intent);
-		Log.d(this, TAG, "Intent extras are "+intent.getExtras().describeContents());
-		Log.d(this, TAG, "Intent extra key list is "+Arrays.toString(intent.getExtras().keySet().toArray()));
+//		Log.d(this, TAG, "Intent extras are "+intent.getExtras().describeContents());
+//		Log.d(this, TAG, "Intent extra key list is "+Arrays.toString(intent.getExtras().keySet().toArray()));
 		if (ActivityRecognitionResult.hasResult(intent)) {
 			ActivityRecognitionResult result = ActivityRecognitionResult.extractResult(intent);
 			DetectedActivity mostProbableActivity = result.getMostProbableActivity();

--- a/src/ios/BEMAppDelegate.h
+++ b/src/ios/BEMAppDelegate.h
@@ -13,10 +13,7 @@
 
 @interface AppDelegate (notification)
 
-@property (retain, nonatomic) TripDiaryStateMachine *tripDiaryStateMachine;
-@property (copy, nonatomic) SilentPushCompletionHandler silentPushHandler;
-
-- (BOOL)didFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
++ (BOOL)didFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:( void (^)(UIBackgroundFetchResult))completionHandler;

--- a/src/ios/BEMDataCollection.h
+++ b/src/ios/BEMDataCollection.h
@@ -1,12 +1,16 @@
 #import <Cordova/CDV.h>
+#import "TripDiaryStateMachine.h"
 
 @interface BEMDataCollection: CDVPlugin
 
+- (void) pluginInitialize;
 - (void) launchInit:(CDVInvokedUrlCommand*)command;
 - (void) getConfig:(CDVInvokedUrlCommand*)command;
 - (void) getState:(CDVInvokedUrlCommand*)command;
 - (void) forceTripStart:(CDVInvokedUrlCommand *)command;
 - (void) forceTripEnd:(CDVInvokedUrlCommand *)command;
 - (void) forceRemotePush:(CDVInvokedUrlCommand *)command;
+
+@property (strong) TripDiaryStateMachine* tripDiaryStateMachine;
 
 @end

--- a/src/ios/BEMDataCollection.m
+++ b/src/ios/BEMDataCollection.m
@@ -1,10 +1,22 @@
 #import "BEMDataCollection.h"
 #import "LocalNotificationManager.h"
 #import "Location/LocationTrackingConfig.h"
-#import "TripDiaryStateMachine.h"
+#import "BEMAppDelegate.h"
 #import <CoreLocation/CoreLocation.h>
 
 @implementation BEMDataCollection
+
+- (void)pluginInitialize
+{
+    // TODO: We should consider adding a create statement to the init, similar
+    // to android - then it doesn't matter if the pre-populated database is not
+    // copied over.
+    NSLog(@"BEMDataCollection:pluginInitialize singleton -> initialize statemachine and delegate");
+    // TODO: Should we do this as part of a separate thread? Will the permission popups work then?
+    self.tripDiaryStateMachine = [TripDiaryStateMachine instance];
+    NSDictionary* emptyOptions = @{};
+    [AppDelegate didFinishLaunchingWithOptions:emptyOptions];
+}
 
 - (void)launchInit:(CDVInvokedUrlCommand*)command
 {
@@ -58,11 +70,7 @@
     NSString* callbackId = [command callbackId];
     
     @try {
-        /*
-        TripDiaryStateMachine* tdsm = [UIApplication sharedApplication].delegate.tripDiaryStateMachine;
-        NSString* stateName = [TripDiaryStateMachine getStateName:tdsm.currState];
-         */
-        NSString* stateName = @"NOT IMPLEMENTED YET";
+        NSString* stateName = [TripDiaryStateMachine getStateName:self.tripDiaryStateMachine.currState];
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_OK
                                    messageAsString:stateName];

--- a/src/ios/BEMRemotePushNotificationHandler.h
+++ b/src/ios/BEMRemotePushNotificationHandler.h
@@ -1,0 +1,8 @@
+#import "BEMServerSyncCommunicationHelper.h"
+
+@interface BEMRemotePushNotificationHandler : NSObject
++ (BEMRemotePushNotificationHandler*) instance;
+- (void) handleNotifications:(NSNotification*)note;
+@property (copy, nonatomic) SilentPushCompletionHandler silentPushHandler;
+
+@end

--- a/src/ios/BEMRemotePushNotificationHandler.m
+++ b/src/ios/BEMRemotePushNotificationHandler.m
@@ -1,0 +1,86 @@
+#import "BEMRemotePushNotificationHandler.h"
+#import "TripDiaryStateMachine.h"
+#import "LocalNotificationManager.h"
+
+@implementation BEMRemotePushNotificationHandler
+
++ (BEMRemotePushNotificationHandler*) instance {
+    static dispatch_once_t once;
+    static id sharedInstance;
+    dispatch_once(&once, ^{
+        sharedInstance = [[self alloc] init];
+        // when we create a new instance, we use it to register for notifications
+        // this should mean that we register only once for notifications, which should mean
+        // that we should stop getting duplicate notifications
+        [sharedInstance registerForNotifications];
+    });
+    return sharedInstance;
+}
+
+- (void)registerForNotifications {
+    [[NSNotificationCenter defaultCenter] addObserverForName:CFCTransitionNotificationName object:nil queue:nil
+                                                  usingBlock:^(NSNotification *note) {
+                                                      [self handleNotifications:note];
+                                                  }];
+}
+
+- (void)handleNotifications:(NSNotification*)note {
+    @synchronized([BEMRemotePushNotificationHandler instance]) {
+        if (self.silentPushHandler == NULL && [note.object isEqualToString:CFCTransitionRecievedSilentPush]) {
+            // We are the silent push handler, so we store the handler block, but don't do anything else.
+            NSDictionary* userInfo = note.userInfo;
+            self.silentPushHandler = [userInfo objectForKey:@"handler"];
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:@"Setting the SILENT_PUSH handler block in the silent push handler"]];
+        }
+    }
+    if (self.silentPushHandler != NULL) {
+        [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                   @"Received notification %@ while processing silent push notification", note.object]];
+        // we only care about notifications when we are processing a silent remote push notification
+        if ([note.object isEqualToString:CFCTransitionRecievedSilentPush]) {
+            // We are the silent push handler, so we store the handler block, but don't do anything else.
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:@"Handler block has already been set, ignoring SILENT_PUSH in the silent push handler"]];
+            // Note: Do NOT call the handler here since the state machine may not have quiesced.
+            // We want to wait until we know that the state machine has finished handling it.
+            // _silentPushHandler(UIBackgroundFetchResultNewData);
+        } else if ([note.object isEqualToString:CFCTransitionNOP]) {
+            // Next, we think of what the possible responses to the silent push are
+            // One option is that the state machine wants to ignore it, possibly because it is not in ONGOING STATE
+            // Let us assume that we will return NOP in that case
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:@"Trip diary state machine ignored the silent push"]];
+            self.silentPushHandler(UIBackgroundFetchResultNewData);
+        } else if ([note.object isEqualToString:CFCTransitionTripEndDetected]) {
+            // Otherwise, if it is in OngoingTrip, it will try to see whether the trip has ended. If it hasn't,
+            // let us assume that we will return a NOP, which is already handled.
+            // If it has, then it will return a TripEndDetected and start creating the geofence.
+            // Once the geofence is created, we will get a TripEnded, and we want to
+            // wait until that point, so we DON'T return here.
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Detected trip end, waiting until geofence is created to return from silent push"]];
+        } else if ([note.object isEqualToString:CFCTransitionTripEnded]) {
+            // Trip has now ended, so we can push and clear data
+            [[BEMServerSyncCommunicationHelper pushAndClearUserCache] continueWithBlock:^id(BFTask *task) {
+                    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                               @"Returning with fetch result = new data"]
+                                                       showUI:TRUE];
+                    self.silentPushHandler(UIBackgroundFetchResultNewData);
+                return nil;
+            }];
+        } else if ([note.object isEqualToString:CFCTransitionTripRestarted]) {
+            // The other option from TripEndDetected is that the trip is restarted instead of ended.
+            // In that case, we still want to finish the handler
+            self.silentPushHandler(UIBackgroundFetchResultNewData);
+        } else {
+            // Some random transition. Might as well call the handler and return
+            self.silentPushHandler(UIBackgroundFetchResultNewData);
+        }
+        // TODO: Figure out whether we should set it to NULL here or whether parts of
+        // the system will still try to access the handler.
+        // _silentPushHandler = nil;
+    } else {
+        // Not processing a silent remote push notification
+        NSLog(@"Ignoring silent push notification");
+    }
+}
+
+@end

--- a/src/ios/BEMRemotePushNotificationHandler.m
+++ b/src/ios/BEMRemotePushNotificationHandler.m
@@ -35,7 +35,7 @@
     }
     if (self.silentPushHandler != NULL) {
         [LocalNotificationManager addNotification:[NSString stringWithFormat:
-                                                   @"Received notification %@ while processing silent push notification", note.object]];
+                                                   @"Received notification %@ while processing silent push notification", note.object] showUI:TRUE];
         // we only care about notifications when we are processing a silent remote push notification
         if ([note.object isEqualToString:CFCTransitionRecievedSilentPush]) {
             // We are the silent push handler, so we store the handler block, but don't do anything else.
@@ -47,7 +47,7 @@
             // Next, we think of what the possible responses to the silent push are
             // One option is that the state machine wants to ignore it, possibly because it is not in ONGOING STATE
             // Let us assume that we will return NOP in that case
-            [LocalNotificationManager addNotification:[NSString stringWithFormat:@"Trip diary state machine ignored the silent push"]];
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:@"Remote push state machine ignored the silent push, fetch result = new data"] showUI:TRUE];
             self.silentPushHandler(UIBackgroundFetchResultNewData);
         } else if ([note.object isEqualToString:CFCTransitionTripEndDetected]) {
             // Otherwise, if it is in OngoingTrip, it will try to see whether the trip has ended. If it hasn't,

--- a/src/ios/Location/DataUtils.m
+++ b/src/ios/Location/DataUtils.m
@@ -217,7 +217,7 @@
                                                                     options:NSJSONReadingMutableContainers
                                                                       error: &error];
     if (jsonDict == nil) {
-        NSLog(@"error %@ while parsing json object %@", error, jsonData);
+        [LocalNotificationManager addNotification:[NSString stringWithFormat:@"error %@ while parsing json object %@", error, jsonData] showUI:FALSE];
     }
     return jsonDict;
 }

--- a/src/ios/Location/TripDiaryDelegate.m
+++ b/src/ios/Location/TripDiaryDelegate.m
@@ -144,7 +144,11 @@
 - (void)locationManager:(CLLocationManager *)manager
           didExitRegion:(CLRegion *)region {
     if([region.identifier compare:kCurrGeofenceID] != NSOrderedSame) {
-        NSLog(@"exited region %@ that does not match current geofence %@", region.identifier, kCurrGeofenceID);
+        [LocalNotificationManager addNotification:
+            [NSString stringWithFormat:@"exited region %@ that does not match current geofence %@",
+                                        region.identifier, kCurrGeofenceID]
+                            showUI:TRUE];
+
     }
     // Since we are going to keep the geofence around during ongoing tracking to ensure that
     // we are re-initalized, we will keep getting exit messages. We need to ignore if we are not
@@ -153,8 +157,11 @@
         [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
                                                             object:CFCTransitionExitedGeofence];
     } else {
-        NSLog(@"Received geofence exit in state %@, ignoring",
-              [TripDiaryStateMachine getStateName:_tdsm.currState]);
+        [LocalNotificationManager addNotification:
+         [NSString stringWithFormat:@"Received geofence exit in state %@, ignoring",
+                [TripDiaryStateMachine getStateName:_tdsm.currState]]
+                                           showUI:TRUE];
+
     }
 }
 
@@ -227,7 +234,8 @@
 
 - (void)locationManager:(CLLocationManager *)manager
             didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-    NSLog(@"New authorization status = %d, always = %d", status, kCLAuthorizationStatusAuthorizedAlways);
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:@"New authorization status = %d, always = %d", status, kCLAuthorizationStatusAuthorizedAlways]];
+
     if (_tdsm.currState == kStartState) {
         [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
                                                             object:CFCTransitionInitialize];

--- a/src/ios/Location/TripDiaryStateMachine.h
+++ b/src/ios/Location/TripDiaryStateMachine.h
@@ -57,7 +57,6 @@ typedef void(^GeofenceStatusCallback)(NSString* geofenceStatus);
 @interface TripDiaryStateMachine : NSObject
 + (TripDiaryStateMachine*) instance;
 
--(id)initRelaunchLocationManager:(BOOL)restart;
 -(void)registerForNotifications;
 
 @property CLLocationManager *locMgr;

--- a/src/ios/Location/TripDiaryStateMachine.h
+++ b/src/ios/Location/TripDiaryStateMachine.h
@@ -55,12 +55,13 @@ typedef enum : NSUInteger {
 typedef void(^GeofenceStatusCallback)(NSString* geofenceStatus);
 
 @interface TripDiaryStateMachine : NSObject
++ (TripDiaryStateMachine*) instance;
+
 -(id)initRelaunchLocationManager:(BOOL)restart;
 -(void)registerForNotifications;
 
 @property CLLocationManager *locMgr;
 @property CMMotionActivityManager *activityMgr;
-
 @property TripDiaryStates currState;
 
 + (NSString*)getStateName:(TripDiaryStates) state;


### PR DESCRIPTION
Right now, the `didFinishLoadingWithOptions` call does not depend on anything in the app delegate and can be moved out. But people are used to having the calls in there in the AppDelegate so let's leave it there for now.