### PR TITLE
Add support for turning location tracking on and off

### DIFF
--- a/src/android/location/TripDiaryStateMachineReceiver.java
+++ b/src/android/location/TripDiaryStateMachineReceiver.java
@@ -132,6 +132,29 @@ public class TripDiaryStateMachineReceiver extends BroadcastReceiver {
         }
     }
 
+    public static void restartCollection(Context ctxt) {
+        /*
+         Super hacky solution, but works for now. Steps are:
+         * Stop tracking
+         * Poll for state change
+         * Start tracking
+         * Ugh! My eyeballs hurt to even read that?!
+         */
+        ctxt.sendBroadcast(new Intent(ctxt.getString(R.string.transition_stop_tracking)));
+        boolean stateChanged = false;
+        while(!stateChanged) {
+            try {
+                Thread.sleep(1000); // Wait for one second in the loop
+                stateChanged = (TripDiaryStateMachineService.getState(ctxt).equals(
+                        ctxt.getString(R.string.state_tracking_stopped)));
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                // Sleep has been interrupted, might as well exit the while loop
+                stateChanged = true;
+            }
+        }
+        ctxt.sendBroadcast(new Intent(ctxt.getString(R.string.transition_start_tracking)));
+    }
 
     private Intent getStateMachineServiceIntent(Context context) {
         if (ConfigManager.getConfig(context).isDutyCycling()) {

--- a/src/ios/BEMAppDelegate.m
+++ b/src/ios/BEMAppDelegate.m
@@ -16,8 +16,6 @@
 #import "ConfigManager.h"
 #import <Parse/Parse.h>
 #import <objc/runtime.h>
-#import "Battery.h"
-#import "BEMBuiltinUserCache.h"
 
 // 3600 secs = 1 hour
 #define ONE_HOUR 60 * 60
@@ -159,25 +157,7 @@
                                                showUI:TRUE];
         }
     } forceRefresh:TRUE];
-    [self saveBatteryAndSimulateUser];
     [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName object:CFCTransitionRecievedSilentPush userInfo:localUserInfo];
-}
-
-- (void) saveBatteryAndSimulateUser
-{
-// TODO: Figure out whether this should be here or in the server sync code or in the trip machine code
-    Battery* batteryInfo = [Battery new];
-    batteryInfo.battery_level_ratio = [UIDevice currentDevice].batteryLevel;
-    batteryInfo.battery_state = [UIDevice currentDevice].batteryState;
-    [[BuiltinUserCache database] putMessage:@"key.usercache.battery" value:batteryInfo];
-    if ([ConfigManager instance].simulate_user_interaction == YES) {
-        UILocalNotification *localNotif = [[UILocalNotification alloc] init];
-        if (localNotif) {
-            localNotif.alertBody = [NSString stringWithFormat:@"Battery level = %@", @(batteryInfo.battery_level_ratio * 100)];
-            localNotif.soundName = UILocalNotificationDefaultSoundName;
-            [[UIApplication sharedApplication] presentLocalNotificationNow:localNotif];
-        }
-    }
 }
 
 @end

--- a/src/ios/BEMDataCollection.h
+++ b/src/ios/BEMDataCollection.h
@@ -6,11 +6,9 @@
 - (void) pluginInitialize;
 - (void) launchInit:(CDVInvokedUrlCommand*)command;
 - (void) getConfig:(CDVInvokedUrlCommand*)command;
-- (void) updateConfig:(CDVInvokedUrlCommand*)command;
+- (void) setConfig:(CDVInvokedUrlCommand*)command;
 - (void) getState:(CDVInvokedUrlCommand*)command;
-- (void) forceTripStart:(CDVInvokedUrlCommand *)command;
-- (void) forceTripEnd:(CDVInvokedUrlCommand *)command;
-- (void) forceRemotePush:(CDVInvokedUrlCommand *)command;
+- (void) forceTransition:(CDVInvokedUrlCommand *)command;
 - (void)getAccuracyOptions:(CDVInvokedUrlCommand *)command;
 
 @property (strong) TripDiaryStateMachine* tripDiaryStateMachine;

--- a/src/ios/Location/DataUtils.h
+++ b/src/ios/Location/DataUtils.h
@@ -27,6 +27,7 @@
 
 + (NSArray*) getLastPoints:(int) nPoints;
 + (BOOL)hasTripEnded:(int)tripEndThresholdMins;
++ (void) saveBatteryAndSimulateUser;
 // + (void) pushAndClearData:(void (^)(BOOL))completionHandler;
 
 @end

--- a/src/ios/Location/DataUtils.m
+++ b/src/ios/Location/DataUtils.m
@@ -18,6 +18,7 @@
 #import "BEMCommunicationHelper.h"
 #import "LocationTrackingConfig.h"
 #import "ConfigManager.h"
+#import "Battery.h"
 
 @implementation DataUtils
 
@@ -245,6 +246,23 @@
     
     NSLog(@"data has %lu bytes, str has size %lu", bytesToSend.length, (unsigned long)strToSend.length);
     return strToSend;
+}
+
++ (void) saveBatteryAndSimulateUser
+{
+    // TODO: Figure out whether this should be here or in the server sync code or in the trip machine code
+    Battery* batteryInfo = [Battery new];
+    batteryInfo.battery_level_ratio = [UIDevice currentDevice].batteryLevel;
+    batteryInfo.battery_state = [UIDevice currentDevice].batteryState;
+    [[BuiltinUserCache database] putMessage:@"key.usercache.battery" value:batteryInfo];
+    if ([ConfigManager instance].simulate_user_interaction == YES) {
+        UILocalNotification *localNotif = [[UILocalNotification alloc] init];
+        if (localNotif) {
+            localNotif.alertBody = [NSString stringWithFormat:@"Battery level = %@", @(batteryInfo.battery_level_ratio * 100)];
+            localNotif.soundName = UILocalNotificationDefaultSoundName;
+            [[UIApplication sharedApplication] presentLocalNotificationNow:localNotif];
+        }
+    }
 }
 
 #if FALSE

--- a/src/ios/Location/TripDiaryStateMachine.h
+++ b/src/ios/Location/TripDiaryStateMachine.h
@@ -33,6 +33,7 @@
 #define CFCTransitionDataPushed @"T_DATA_PUSHED"
 #define CFCTransitionForceStopTracking @"T_FORCE_STOP_TRACKING"
 #define CFCTransitionTrackingStopped @"T_TRACKING_STOPPED"
+#define CFCTransitionStartTracking @"T_START_TRACKING"
 #define CFCTransitionVisitStarted @"T_VISIT_STARTED"
 #define CFCTransitionVisitEnded @"T_VISIT_ENDED"
 #define CFCTransitionNOP @"T_NOP"
@@ -50,7 +51,8 @@
 typedef enum : NSUInteger {
     kStartState,
     kWaitingForTripStartState,
-    kOngoingTripState
+    kOngoingTripState,
+    kTrackingStoppedState
 } TripDiaryStates;
 
 typedef void(^GeofenceStatusCallback)(NSString* geofenceStatus);

--- a/www/datacollection.js
+++ b/www/datacollection.js
@@ -43,14 +43,10 @@ var DataCollection = {
     getState: function (successCallback, errorCallback) {
         exec(successCallback, errorCallback, "DataCollection", "getState", []);
     },
-    forceTripStart: function (successCallback, errorCallback) {
-        exec(successCallback, errorCallback, "DataCollection", "forceTripStart", []);
-    },
-    forceTripEnd: function (successCallback, errorCallback) {
-        exec(successCallback, errorCallback, "DataCollection", "forceTripEnd", []);
-    },
-    forceRemotePush: function (successCallback, errorCallback) {
-        exec(successCallback, errorCallback, "DataCollection", "forceRemotePush", []);
+    forceTransition: function (generalTransitionName) {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "DataCollection", "forceTransition", [generalTransitionName]);
+        });
     }
 }
 


### PR DESCRIPTION
We already had support for turning tracking off, but then we just went back to
the start state. That is not a good solution because in order to make the
normal case more robust, we re-send the initialize transition if we are in the
start state.

So now, when we turn tracking off, we go to a different state
`tracking_stopped`, and the only way to get out of it is to recieve a new
`start_tracking` transition.

Also:
- refactored the plugin interface code to force general transitions instead of
  expanding the existing hardcoded list.
- ensured that the state machine is reset when the config changes through UI
  input by turning tracking on and off

The second of these is a workaround, not a real solution, since it doesn't deal
with automatic updates from the server that could come in as part of the sync,
and it is not clear that stopping and restarting tracking (or at least, doing
so in the current, hacky way) is the best way to reset.

Long-term solution is tracked at:
https://github.com/e-mission/e-mission-data-collection/issues/105