### PR TITLE
Two minor fixes to the data collection changes

### DIFF
--- a/src/android/BootReceiver.java
+++ b/src/android/BootReceiver.java
@@ -8,6 +8,7 @@ import edu.berkeley.eecs.emission.R;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.Log;
 import edu.berkeley.eecs.emission.cordova.usercache.UserCacheFactory;
 import edu.berkeley.eecs.emission.cordova.tracker.wrapper.Transition;
+import edu.berkeley.eecs.emission.cordova.tracker.location.TripDiaryStateMachineService;
 
 /*
  * Class that allows us to re-register the alarms when the phone is rebooted.
@@ -32,8 +33,11 @@ public class BootReceiver extends BroadcastReceiver {
              */
             // DataUtils.endTrip(ctx);
 
-            // Re-initialize the state machine
-            ctx.sendBroadcast(new Intent(ctx.getString(R.string.transition_initialize)));
+            // Re-initialize the state machine if we haven't stopped tracking
+            if (!TripDiaryStateMachineService.getState(ctxt).equals(
+                    ctxt.getString(R.string.state_tracking_stopped))) {
+                ctx.sendBroadcast(new Intent(ctx.getString(R.string.transition_initialize)));
+            }
         }
 	}
 }

--- a/src/android/wrapper/LocationTrackingConfig.java
+++ b/src/android/wrapper/LocationTrackingConfig.java
@@ -19,7 +19,7 @@ public class LocationTrackingConfig {
         this.filter_distance = -1; // unused
         this.filter_time = Constants.THIRTY_SECONDS;
         this.geofence_radius = Constants.TRIP_EDGE_THRESHOLD;
-        this.trip_end_stationary_mins = FIVE_MINUTES_IN_SEC;
+        this.trip_end_stationary_mins = 5;
         this.android_geofence_responsiveness = 5 * Constants.MILLISECONDS;
     }
 


### PR DESCRIPTION
- Change the default tripEndStationaryMins to 5 minutes instead of 5 * 60 minutes!
- Ensure that we don't inadvertently turn on tracking when the user has asked to stop it when the phone reboots