### PR TITLE
Turn off UI alerts unless the user wants them for debugging

### DIFF
--- a/src/android/location/ActivityRecognitionChangeIntentService.java
+++ b/src/android/location/ActivityRecognitionChangeIntentService.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import com.google.android.gms.location.ActivityRecognitionResult;
 import com.google.android.gms.location.DetectedActivity;
 
+import edu.berkeley.eecs.emission.cordova.tracker.ConfigManager;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.NotificationHelper;
 import edu.berkeley.eecs.emission.R;
 
@@ -34,8 +35,10 @@ public class ActivityRecognitionChangeIntentService extends IntentService {
 			ActivityRecognitionResult result = ActivityRecognitionResult.extractResult(intent);
 			DetectedActivity mostProbableActivity = result.getMostProbableActivity();
 			Log.i(this, TAG, "Detected new activity "+mostProbableActivity);
+			if (ConfigManager.getConfig(this).isSimulateUserInteraction()) {
 			NotificationHelper.createNotification(this, ACTIVITY_IN_NUMBERS,
 					"Detected new activity "+activityType2Name(mostProbableActivity.getType()));
+			}
 			// TODO: Do we want to compare activity and only store when different?
             // Can easily do that by getting the last activity
             // Let's suck everything up to the server for now and optimize later

--- a/src/android/location/TripDiaryStateMachineService.java
+++ b/src/android/location/TripDiaryStateMachineService.java
@@ -22,6 +22,7 @@ import com.google.android.gms.location.LocationServices;
 import java.util.LinkedList;
 import java.util.List;
 
+import edu.berkeley.eecs.emission.cordova.tracker.ConfigManager;
 import edu.berkeley.eecs.emission.cordova.tracker.sensors.BatteryUtils;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.NotificationHelper;
 import edu.berkeley.eecs.emission.R;
@@ -233,11 +234,15 @@ public class TripDiaryStateMachineService extends Service implements
                         String newState = fCtxt.getString(R.string.state_waiting_for_trip_start);
                         if (status.isSuccess()) {
                             setNewState(newState);
+                            if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                             NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                     "Success moving to " + newState);
+                            }
                         } else {
+                            if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                             NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                     "Failed moving to " + newState);
+                        }
                         }
                         mApiClient.disconnect();
                     }
@@ -279,11 +284,15 @@ public class TripDiaryStateMachineService extends Service implements
                     String newState = fCtxt.getString(R.string.state_ongoing_trip);
                     if (batchResult.getStatus().isSuccess()) {
                         setNewState(newState);
+                        if (ConfigManager.getConfig(fCtxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Success moving to "+newState);
+                        }
                     } else {
+                        if (ConfigManager.getConfig(fCtxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Failed moving to "+newState+" failed");
+                    }
                     }
                     mApiClient.disconnect();
                 }
@@ -301,11 +310,15 @@ public class TripDiaryStateMachineService extends Service implements
                     String newState = fCtxt.getString(R.string.state_tracking_stopped);
                     if (batchResult.getStatus().isSuccess()) {
                         setNewState(newState);
+                        if (ConfigManager.getConfig(fCtxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Success moving to "+newState);
+                        }
                     } else {
+                        if (ConfigManager.getConfig(fCtxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Failed moving to "+newState);
+                    }
                     }
                     mApiClient.disconnect();
                 }
@@ -348,11 +361,15 @@ public class TripDiaryStateMachineService extends Service implements
                             }
                     if (batchResult.getStatus().isSuccess()) {
                         setNewState(newState);
+                        if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Success moving to "+newState);
+                        }
                     } else {
+                        if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Failed moving to "+newState);
+                    }
                     }
                     mApiClient.disconnect();
                 }
@@ -373,11 +390,15 @@ public class TripDiaryStateMachineService extends Service implements
                     String newState = fCtxt.getString(R.string.state_tracking_stopped);
                     if (batchResult.getStatus().isSuccess()) {
                         setNewState(newState);
+                        if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Success moving to " + newState);
+                        }
                     } else {
+                        if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Failed moving to " + newState);
+                    }
                     }
                     mApiClient.disconnect();
                 }
@@ -405,11 +426,15 @@ public class TripDiaryStateMachineService extends Service implements
                     String newState = fCtxt.getString(R.string.state_tracking_stopped);
                     if (batchResult.getStatus().isSuccess()) {
                         setNewState(newState);
+                        if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Success moving to "+newState);
+                        }
                     } else {
+                        if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Failed moving to "+newState);
+                    }
                     }
                     mApiClient.disconnect();
                 }

--- a/src/android/location/TripDiaryStateMachineServiceOngoing.java
+++ b/src/android/location/TripDiaryStateMachineServiceOngoing.java
@@ -21,6 +21,7 @@ import com.google.android.gms.location.LocationServices;
 import java.util.LinkedList;
 import java.util.List;
 
+import edu.berkeley.eecs.emission.cordova.tracker.ConfigManager;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.NotificationHelper;
 import edu.berkeley.eecs.emission.R;
 import edu.berkeley.eecs.emission.cordova.tracker.location.actions.ActivityRecognitionActions;
@@ -249,11 +250,15 @@ public class TripDiaryStateMachineServiceOngoing extends Service implements
                     String newState = fCtxt.getString(R.string.state_tracking_stopped);
                     if (batchResult.getStatus().isSuccess()) {
                         setNewState(newState);
+                        if (ConfigManager.getConfig(fCtxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Success moving to " + newState);
+                        }
                     } else {
+                        if (ConfigManager.getConfig(fCtxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Failed moving to " + newState);
+                    }
                     }
                     mApiClient.disconnect();
                 }
@@ -287,11 +292,15 @@ public class TripDiaryStateMachineServiceOngoing extends Service implements
                 String newState = fCtxt.getString(R.string.state_ongoing_trip);
                 if (batchResult.getStatus().isSuccess()) {
                     setNewState(newState);
+                    if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                     NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                             "Success moving to " + newState);
+                    }
                 } else {
+                    if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                     NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                             "Failed moving to " + newState + " failed");
+                }
                 }
                 mApiClient.disconnect();
             }


### PR DESCRIPTION
User wants them == "simulateUserInteraction"
Unlike iOS, this does not introduce a new dependency, it does have a lot of
repeated code, specially in the services when we try to transition to a new
state.

Fixing it is being tracked in
https://github.com/e-mission/e-mission-data-collection/issues/113

Note that the iOS change changes the logging directly, so it is not checked
into this repo. The iOS change is at:
https://github.com/shankari/cordova-unified-logger/commit/f55fc2dd15f157b1d4a77c496d55a56f717621e2

This is an object case in the pitfalls of both approaches - we just need to
refactor and do them right on the second pass.