### PR TITLE
Minor fix to support change of timequery key from int -> string

### DIFF
--- a/src/android/location/LocationChangeIntentService.java
+++ b/src/android/location/LocationChangeIntentService.java
@@ -109,7 +109,7 @@ public class LocationChangeIntentService extends IntentService {
         SimpleLocation[] last10Points = uc.getLastSensorData(R.string.key_usercache_filtered_location, pointsToQuery , SimpleLocation.class);
 
         double nowSecs = ((double)System.currentTimeMillis())/1000;
-        UserCache.TimeQuery tq = new UserCache.TimeQuery(R.string.metadata_usercache_write_ts,
+        UserCache.TimeQuery tq = new UserCache.TimeQuery(getString(R.string.metadata_usercache_write_ts),
                 nowSecs - tripEndSecs - 10, nowSecs);
 
         Log.d(this, TAG, "Finding points in the range "+tq);

--- a/src/ios/Location/DataUtils.m
+++ b/src/ios/Location/DataUtils.m
@@ -111,7 +111,7 @@
     double startTs = nowTs - nMinutes * 60;
     
     TimeQuery* tq = [TimeQuery new];
-    tq.timeKey = @"metadata.usercache.write_ts";
+    tq.timeKey = [[BuiltinUserCache database] getStatName:@"metadata.usercache.write_ts"];
     tq.startTs = startTs;
     tq.endTs = nowTs;
 


### PR DESCRIPTION
Change as done to make it easier to support timequeries from javascript
through the plugin interface. usercache change was in
https://github.com/shankari/cordova-usercache/commit/987432516f4def023d8c884b04c5d6893cc781a1