### PR TITLE
Don't always return "true" for consent + move api client creation to …

### DIFF
--- a/src/ios/ConfigManager.m
+++ b/src/ios/ConfigManager.m
@@ -54,8 +54,6 @@ static LocationTrackingConfig *_instance;
     }
     } @catch (NSException *exception) {
         return false;
-    } @finally {
-        return true;
     }
 }
 


### PR DESCRIPTION
…onCreate

Addresses two issues found in testing.
- we were returning true from a finally block, which meant that we were always consenting
- we needed to initialize the ApiClient in the onCreate method
(https://github.com/e-mission/e-mission-data-collection/issues/13)