### PR TITLE
Add the new wrapper classes to be used for client stats

### DIFF
--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -23,8 +23,10 @@ import edu.berkeley.eecs.emission.*;
 import edu.berkeley.eecs.emission.cordova.tracker.wrapper.ConsentConfig;
 import edu.berkeley.eecs.emission.cordova.tracker.wrapper.LocationTrackingConfig;
 import edu.berkeley.eecs.emission.cordova.tracker.location.TripDiaryStateMachineReceiver;
+import edu.berkeley.eecs.emission.cordova.tracker.wrapper.StatsEvent;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.Log;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.NotificationHelper;
+import edu.berkeley.eecs.emission.cordova.usercache.BuiltinUserCache;
 
 public class DataCollectionPlugin extends CordovaPlugin {
     public static String TAG = "DataCollectionPlugin";
@@ -46,6 +48,8 @@ public class DataCollectionPlugin extends CordovaPlugin {
             NotificationHelper.createNotification(myActivity, Constants.TRACKING_ERROR_ID,
                     "Unable to connect to google play services, tracking turned off");
         }
+        BuiltinUserCache.getDatabase(myActivity).putMessage(R.string.key_usercache_client_nav_event,
+                new StatsEvent(myActivity, R.string.app_launched));
     }
 
     @Override

--- a/src/android/wrapper/StatsEvent.java
+++ b/src/android/wrapper/StatsEvent.java
@@ -1,0 +1,34 @@
+package edu.berkeley.eecs.emission.cordova.tracker.wrapper;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+
+import java.util.jar.Attributes;
+
+public class StatsEvent {
+    public StatsEvent(Context ctxt, int name_id) {
+        this(ctxt, name_id, -1);
+    }
+
+    public StatsEvent(Context ctxt, int name_id, double reading) {
+        // we're passing all info in seconds, so we divide by 1000
+        this(ctxt, name_id, ((double)System.currentTimeMillis())/1000, reading);
+    }
+
+    public StatsEvent(Context ctxt, int name_id, double ts_secs, double reading) {
+        this.name = ctxt.getString(name_id);
+        this.ts = ts_secs;
+        this.reading = reading;
+        try {
+            this.client_app_version = ctxt.getPackageManager().getPackageInfo(ctxt.getPackageName(), 0).versionName;
+        } catch (PackageManager.NameNotFoundException e) {
+            this.client_app_version = "UNKNOWN";
+        }
+        this.client_os_version = android.os.Build.VERSION.RELEASE;
+    }
+    private String name;
+    private double reading;
+    private double ts;
+    private String client_app_version;
+    private String client_os_version;
+}

--- a/src/android/wrapper/Timer.java
+++ b/src/android/wrapper/Timer.java
@@ -1,0 +1,17 @@
+package edu.berkeley.eecs.emission.cordova.tracker.wrapper;
+
+/**
+ * Created by shankari on 10/30/16.
+ *
+ */
+
+public class Timer {
+    private long startMillis;
+    public Timer() {
+        this.startMillis = System.currentTimeMillis();
+    };
+
+    public double elapsedSecs() {
+        return ((double)(System.currentTimeMillis() - startMillis))/1000;
+    }
+}

--- a/src/ios/BEMDataCollection.m
+++ b/src/ios/BEMDataCollection.m
@@ -4,6 +4,8 @@
 #import "BEMAppDelegate.h"
 #import "ConfigManager.h"
 #import "DataUtils.h"
+#import "StatsEvent.h"
+#import "BEMBuiltinUserCache.h"
 #import <CoreLocation/CoreLocation.h>
 
 @implementation BEMDataCollection
@@ -14,6 +16,10 @@
     // to android - then it doesn't matter if the pre-populated database is not
     // copied over.
     NSLog(@"BEMDataCollection:pluginInitialize singleton -> initialize statemachine and delegate");
+    
+    StatsEvent* se = [[StatsEvent alloc] initForEvent:@"app_launched"];
+    [[BuiltinUserCache database] putMessage:@"key.usercache.client_nav_event" value:se];
+
     // NOTE: This CANNOT be part of a background thread because when the geofence creation, and more importantly,
     // the visit notification, are run as part of a background thread, they don't work.
     // I tried to move this into a background thread as part of a18f8f9385bdd9e37f7b412b386a911aee9a6ea0 and had

--- a/src/ios/Wrapper/StatsEvent.h
+++ b/src/ios/Wrapper/StatsEvent.h
@@ -1,0 +1,22 @@
+//
+//  StatsEvent.h
+//  emission
+//
+//  Created by Kalyanaraman Shankari on 10/31/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface StatsEvent : NSObject
+
+- (instancetype)initForEvent:(NSString*)statName;
+- (instancetype)initForReading:(NSString*)statName withReading:(double)reading;
+
+@property NSString* name;
+@property double ts;
+@property double reading;
+@property NSString* client_app_version;
+@property NSString* client_os_version;
+
+@end

--- a/src/ios/Wrapper/StatsEvent.m
+++ b/src/ios/Wrapper/StatsEvent.m
@@ -1,0 +1,54 @@
+//
+//  StatsEvent.m
+//  emission
+//
+//  Created by Kalyanaraman Shankari on 10/31/16.
+//
+//
+
+#import "StatsEvent.h"
+
+static NSDictionary *statsNamesDict;
+static NSString* appVersion;
+
+@implementation StatsEvent
++ (void)initialize
+{
+    if(self == [StatsEvent class]) {
+        // Read the list of valid keys
+        NSString *plistStatNamesPath = [[NSBundle mainBundle] pathForResource:@"app_stats" ofType:@"plist"];
+        statsNamesDict = [[NSDictionary alloc] initWithContentsOfFile:plistStatNamesPath];
+        
+        // Read the app version
+        NSString *emissionInfoPath = [[NSBundle mainBundle] pathForResource:@"Info" ofType:@"plist"];
+        NSDictionary *infoDict = [[NSDictionary alloc] initWithContentsOfFile:emissionInfoPath];
+        appVersion = [infoDict objectForKey:@"CFBundleShortVersionString"];
+    }
+}
+
+/*
+ * If we want to be really safe, we should really create methods for each of these. But I am
+ * not enthused about that level of busy work. While this does not provide a compile time check,
+ * it at least provides a run time check. Let's stick with that for now.
+ */
++ (NSString*)getStatName:(NSString*)label {
+    return [statsNamesDict objectForKey:label];
+}
+
+-(instancetype)initForEvent:(NSString *)statName
+{
+    return [self initForReading:statName withReading:-1];
+}
+
+-(instancetype)initForReading:(NSString *)statName withReading:(double)reading
+{
+    self = [super init];
+    self.name = [StatsEvent getStatName:statName];
+    self.ts = [[NSDate date] timeIntervalSince1970];
+    self.reading = reading;
+    self.client_app_version = appVersion;
+    self.client_os_version = [[UIDevice currentDevice] systemVersion];
+    return self;
+}
+
+@end

--- a/src/ios/Wrapper/Timer.h
+++ b/src/ios/Wrapper/Timer.h
@@ -1,0 +1,14 @@
+//
+//  Timer.h
+//  emission
+//
+//  Created by Kalyanaraman Shankari on 10/31/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface Timer : NSObject
+- (instancetype) init;
+- (NSTimeInterval) elapsed_secs;
+@end

--- a/src/ios/Wrapper/Timer.m
+++ b/src/ios/Wrapper/Timer.m
@@ -1,0 +1,28 @@
+//
+//  Timer.m
+//  emission
+//
+//  Created by Kalyanaraman Shankari on 10/31/16.
+//
+//
+
+#import "Timer.h"
+
+@interface Timer() {
+    NSDate* _startDate;
+}
+@end
+
+@implementation Timer
+
+- (instancetype) init {
+    self = [super init];
+    _startDate = [NSDate date];
+    return self;
+}
+
+- (NSTimeInterval) elapsed_secs {
+    return [[NSDate date] timeIntervalSinceDate:_startDate];
+}
+
+@end


### PR DESCRIPTION
Also add an app_launched client stats invocation on pluginInitialize, since we
are deleting the client_stats code.

New wrapper classes are used in https://github.com/e-mission/cordova-server-sync/pull/22/commits/8a4dfba133b07e26180a412906bdbe8ccddc4e2a
and the corresponding main change is https://github.com/e-mission/cordova-usercache/pull/26/commits/67ae0c9d8d6fe454d3dfded1a46d95b262f75aac