### PR TITLE
Ensure that we prompt for consent from remote push/visit notification…

### DIFF
--- a/src/ios/BEMAppDelegate.h
+++ b/src/ios/BEMAppDelegate.h
@@ -14,6 +14,8 @@
 @interface AppDelegate (notification)
 
 + (BOOL)didFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
++ (NSString*) getReqConsent;
++ (void) checkNativeConsent;
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:( void (^)(UIBackgroundFetchResult))completionHandler;

--- a/src/ios/Location/TripDiaryDelegate.m
+++ b/src/ios/Location/TripDiaryDelegate.m
@@ -15,6 +15,7 @@
 #import "SimpleLocation.h"
 #import "LocationTrackingConfig.h"
 #import "ConfigManager.h"
+#import "BEMAppDelegate.h"
 
 #define ACCURACY_THRESHOLD 200
 
@@ -243,7 +244,7 @@
     [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                @"Received visit notification = %@",
                                                visit] showUI:true];
-
+    [AppDelegate checkNativeConsent];
     // According to the design pattern that I have followed here, I should post a notification from here
     // which will be handled by the state machine. However, as we have seen in the past, this does not really work
     // completely, because if a trip has ended, we want to create a geofence, and when we start monitoring the geofence,


### PR DESCRIPTION
…s as well

We don't always load the full app if the app is in the background.
In practice, leaving the prompt only in the plugin caused it to never trigger,
as reported by users who did have the consent magically deleted.

Putting the checks in here caused us to have alerts when we
manually deleted the consent and roamed around.

TODO: We might want to consider moving the current consent requirements to an
xml/plist file instead of the current config.xml. That ensures that we can read
it in background native code without having to do creative stuff with XML parsers.