### PR TITLE
Add a timestamp to Transition and Battery objects

### DIFF
--- a/src/android/BootReceiver.java
+++ b/src/android/BootReceiver.java
@@ -24,7 +24,7 @@ public class BootReceiver extends BroadcastReceiver {
             Log.i(ctx, TAG, "BootReceiver.onReceive called");
             // TODO: Use a different wrapper? Or a different key?
             UserCacheFactory.getUserCache(ctx).putMessage(R.string.key_usercache_transition,
-                    new Transition("unknown", "booted"));
+                    new Transition("unknown", "booted", ((double)System.currentTimeMillis())/1000));
 
             /*
              * End any ongoing trips, because the elapsed time will get reset at this

--- a/src/android/location/TripDiaryStateMachineService.java
+++ b/src/android/location/TripDiaryStateMachineService.java
@@ -108,7 +108,7 @@ public class TripDiaryStateMachineService extends Service implements
             this.getString(R.string.state_start));
         Log.d(this, TAG, "after reading from the prefs, the current state is "+mCurrState);
         UserCacheFactory.getUserCache(this).putMessage(R.string.key_usercache_transition,
-                new Transition(mCurrState, mTransition));
+                new Transition(mCurrState, mTransition, ((double)System.currentTimeMillis())/1000));
 
         if (mApiClient.isConnected()) {
             Log.d(this, TAG, "client is already connected, can directly handle the action");

--- a/src/android/location/TripDiaryStateMachineServiceOngoing.java
+++ b/src/android/location/TripDiaryStateMachineServiceOngoing.java
@@ -104,7 +104,7 @@ public class TripDiaryStateMachineServiceOngoing extends Service implements
             this.getString(R.string.state_start));
         Log.d(this, TAG, "after reading from the prefs, the current state is "+mCurrState);
         UserCacheFactory.getUserCache(this).putMessage(R.string.key_usercache_transition,
-                new Transition(mCurrState, mTransition));
+                new Transition(mCurrState, mTransition, ((double)System.currentTimeMillis())/1000));
 
         // And then connect to the client. All subsequent processing will be in the onConnected
         // method

--- a/src/android/wrapper/Battery.java
+++ b/src/android/wrapper/Battery.java
@@ -20,6 +20,7 @@ public class Battery {
         android_technology = batteryChangedIntent.getStringExtra(BatteryManager.EXTRA_TECHNOLOGY);
         android_temperature = batteryChangedIntent.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, -1);
         android_voltage = batteryChangedIntent.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, -1);
+        ts = ((double)System.currentTimeMillis())/1000;
     }
 
     private String getHealthString(int healthConstant) {
@@ -54,4 +55,5 @@ public class Battery {
     private String android_technology;
     private int android_temperature;
     private int android_voltage;
+    private double ts;
 }

--- a/src/android/wrapper/Transition.java
+++ b/src/android/wrapper/Transition.java
@@ -4,14 +4,29 @@ package edu.berkeley.eecs.emission.cordova.tracker.wrapper;
  * Created by shankari on 7/12/15.
  */
 public class Transition {
+    public String getTransition() {
+        return transition;
+    }
+
+    public String getCurrState() {
+        return currState;
+    }
+
+    public double getTs() {
+        return ts;
+    }
+
     private String currState;
     private String transition;
+
+    private double ts;
     // Should we put newState in here as well?
     // If so, we will need to change the location of the save
 
     public Transition() {}
-    public Transition(String currState, String transition) {
+    public Transition(String currState, String transition, double ts) {
         this.currState = currState;
         this.transition = transition;
+        this.ts = ts;
     }
 }

--- a/src/ios/Location/DataUtils.m
+++ b/src/ios/Location/DataUtils.m
@@ -257,6 +257,7 @@
     Battery* batteryInfo = [Battery new];
     batteryInfo.battery_level_ratio = [UIDevice currentDevice].batteryLevel;
     batteryInfo.battery_status = [UIDevice currentDevice].batteryState;
+    batteryInfo.ts = [BuiltinUserCache getCurrentTimeSecs];
     [[BuiltinUserCache database] putMessage:@"key.usercache.battery" value:batteryInfo];
     if ([ConfigManager instance].simulate_user_interaction == YES) {
         UILocalNotification *localNotif = [[UILocalNotification alloc] init];

--- a/src/ios/Location/TripDiaryStateMachine.m
+++ b/src/ios/Location/TripDiaryStateMachine.m
@@ -159,6 +159,7 @@ static NSString * const kCurrState = @"CURR_STATE";
     Transition* transitionWrapper = [Transition new];
     transitionWrapper.currState = [TripDiaryStateMachine getStateName:self.currState];
     transitionWrapper.transition = transition;
+    transitionWrapper.ts = [BuiltinUserCache getCurrentTimeSecs];
     [[BuiltinUserCache database] putMessage:@"key.usercache.transition" value:transitionWrapper];
     [DataUtils saveBatteryAndSimulateUser];
     

--- a/src/ios/Wrapper/Battery.h
+++ b/src/ios/Wrapper/Battery.h
@@ -14,5 +14,6 @@
 // on the server side.
 @property float battery_level_ratio;
 @property UIDeviceBatteryState battery_status;
+@property double ts;
 
 @end

--- a/src/ios/Wrapper/Transition.h
+++ b/src/ios/Wrapper/Transition.h
@@ -12,5 +12,6 @@
 
 @property NSString* currState;
 @property NSString* transition;
+@property double ts;
 
 @end


### PR DESCRIPTION
Before this, we have not used these objects on the client, only on the server.
On the server, we do have a `ts` that we have copied the metadata `write_ts` to.
Now that we want to use the transition objects on the client too, we can either:
a) read the full object, including metadata, which means we can't use the wrappers
b) add a timestamp to the object

b) seems nicer because:
- it allows us to potentially get rid of the formatters later
- allows us to generate and save at different times
- makes all objects more standardized

So that is what we will do!