### PR TITLE
Add a description of why we use the motion sensors

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -153,6 +153,10 @@
         <string>Our app would like to collect your location information in the background</string>
     </config-file>
 
+    <config-file target="*-Info.plist" parent="NSMotionUsageDescription">
+        <string>Our app uses the motion sensors to determine the transportation mode for the sections of your trip</string>
+    </config-file>
+
     <config-file target="*-Info.plist" parent="ITSAppUsesNonExemptEncryption">
         <false/>
     </config-file>


### PR DESCRIPTION
This is to avoid the following error message from the play store.

> Missing Info.plist key - This app attempts to access privacy-sensitive data
> without a usage description. The app's Info.plist must contain an
> NSMotionUsageDescription key with a string value explaining to the user how the
> app uses this data.

The interesting thing is that this doesn't happen all the time, only
occasionally. But when it does happen, it is annoying because then I have to
bump up the version number and then the android and iOS version numbers are
slightly different occasionally.