### PR TITLE
Switch to a standard auth token creation interface

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.datacollection"
-        version="1.0.2">
+        version="1.0.3">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/ios/BEMAppDelegate.m
+++ b/src/ios/BEMAppDelegate.m
@@ -17,7 +17,7 @@
 #import "BEMServerSyncPlugin.h"
 #import "Cordova/CDVConfigParser.h"
 #import <objc/runtime.h>
-#import "AuthCompletionHandler.h"
+#import "AuthTokenCreationFactory.h"
 
 @implementation AppDelegate (datacollection)
 
@@ -147,16 +147,15 @@
     NSLog(@"About to check whether a trip has ended");
     NSDictionary* localUserInfo = @{@"handler": completionHandler};
     
-    [[AuthCompletionHandler sharedInstance] getValidAuth:^(GIDGoogleUser *user, NSError *error) {
+    [[AuthTokenCreationFactory getInstance] getExpirationDate:^(NSString *expirationDate, NSError *error) {
         /*
          * Note that we do not condition any further tasks on this refresh. That is because, in general, we expect that
          * the token refreshed at this time will be used to push the next set of values. This is just pre-emptive refreshing,
          * to increase the chance that we will finish pushing our data within the 30 sec interval.
          */
         if (error == NULL) {
-            GIDAuthentication* currAuth = user.authentication;
             [LocalNotificationManager addNotification:[NSString stringWithFormat:
-                                                       @"Finished refreshing token in background, new expiry is %@", currAuth.idTokenExpirationDate]
+                                                       @"Finished refreshing token in background, new expiry is %@",expirationDate]
                                                showUI:FALSE];
         } else {
             [LocalNotificationManager addNotification:[NSString stringWithFormat:

--- a/src/ios/Location/TripDiaryStateMachine.m
+++ b/src/ios/Location/TripDiaryStateMachine.m
@@ -17,7 +17,7 @@
 
 #import "LocationTrackingConfig.h"
 #import "ConfigManager.h"
-#import "AuthCompletionHandler.h"
+#import "AuthTokenCreationFactory.h"
 #import "DataUtils.h"
 
 #import <CoreMotion/CoreMotion.h>
@@ -444,16 +444,15 @@ static NSString * const kCurrState = @"CURR_STATE";
 
 - (void) forceRefreshToken
 {
-    [[AuthCompletionHandler sharedInstance] getValidAuth:^(GIDGoogleUser *user, NSError *error) {
+    [[AuthTokenCreationFactory getInstance] getExpirationDate:^(NSString *expirationDate, NSError *error) {
         /*
          * Note that we do not condition any further tasks on this refresh. That is because, in general, we expect that
          * the token refreshed at this time will be used to push the next set of values. This is just pre-emptive refreshing,
          * to increase the chance that we will finish pushing our data within the 30 sec interval.
          */
         if (error == NULL) {
-            GIDAuthentication* currAuth = user.authentication;
             [LocalNotificationManager addNotification:[NSString stringWithFormat:
-                                                       @"Finished refreshing token in background, new expiry is %@", currAuth.idTokenExpirationDate]
+                                                       @"Finished refreshing token in background, new expiry is %@", expirationDate]
                                                showUI:FALSE];
         } else {
             [LocalNotificationManager addNotification:[NSString stringWithFormat:


### PR DESCRIPTION
From the specific google implementation used earlier
This corresponds to the changes in
https://github.com/e-mission/cordova-jwt-auth/pull/18