### PR TITLE
Change the cordova imports to remove ambiguity

### DIFF
--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -1,6 +1,8 @@
 package edu.berkeley.eecs.emission.cordova.tracker;
 
-import org.apache.cordova.*;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CallbackContext;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;


### PR DESCRIPTION
Otherwise, we get the error. Better to have unambigious imports anyway.

```
/Users/shankari/e-mission/e-mission-phone/platforms/android/src/edu/berkeley/eecs/emission/cordova/tracker/DataCollectionPlugin.java:51: error: reference to R is ambiguous
        BuiltinUserCache.getDatabase(myActivity).putMessage(R.string.key_usercache_client_nav_event,
                                                            ^
  both class edu.berkeley.eecs.emission.R in edu.berkeley.eecs.emission and class org.apache.cordova.R in org.apache.cordova match
/Users/shankari/e-mission/e-mission-phone/platforms/android/src/edu/berkeley/eecs/emission/cordova/tracker/DataCollectionPlugin.java:52: error: reference to R is ambiguous
                new StatsEvent(myActivity, R.string.app_launched));
                                           ^
  both class edu.berkeley.eecs.emission.R in edu.berkeley.eecs.emission and class org.apache.cordova.R in org.apache.cordova match
/Users/shankari/e-mission/e-mission-phone/platforms/android/src/edu/berkeley/eecs/emission/cordova/tracker/DataCollectionPlugin.java:89: error: reference to R is ambiguous
            String state = prefs.getString(ctxt.getString(R.string.curr_state_key), ctxt.getString(R.string.state_start));
                                                          ^
```