### PR TITLE
Turn on a foreground service with associated notification on android 8+

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.datacollection"
-        version="1.0.5">
+        version="1.0.6">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really
@@ -89,6 +89,11 @@
             android:exported="false">
         </service>
         <service
+            android:name="edu.berkeley.eecs.emission.cordova.tracker.location.TripDiaryStateMachineForegroundService"
+            android:enabled="true"
+            android:exported="false">
+        </service>
+        <service
 		    android:name="edu.berkeley.eecs.emission.cordova.tracker.location.GeofenceExitIntentService"
 		    android:enabled="true" 
 		    android:exported="false">
@@ -119,6 +124,7 @@
     <source-file src="src/android/location/TripDiaryStateMachineReceiver.java" target-dir="src/edu/berkeley/eecs/emission/cordova/tracker/location"/>
     <source-file src="src/android/location/TripDiaryStateMachineService.java" target-dir="src/edu/berkeley/eecs/emission/cordova/tracker/location"/>
     <source-file src="src/android/location/TripDiaryStateMachineServiceOngoing.java" target-dir="src/edu/berkeley/eecs/emission/cordova/tracker/location"/>
+    <source-file src="src/android/location/TripDiaryStateMachineForegroundService.java" target-dir="src/edu/berkeley/eecs/emission/cordova/tracker/location"/>
     <source-file src="src/android/location/actions/ActivityRecognitionActions.java" target-dir="src/edu/berkeley/eecs/emission/cordova/tracker/location/actions"/>
     <source-file src="src/android/location/actions/GeofenceActions.java" target-dir="src/edu/berkeley/eecs/emission/cordova/tracker/location/actions"/>
     <source-file src="src/android/location/actions/GeofenceLocationIntentService.java" target-dir="src/edu/berkeley/eecs/emission/cordova/tracker/location/actions"/>

--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -52,6 +52,7 @@ public class DataCollectionPlugin extends CordovaPlugin {
         }
         BuiltinUserCache.getDatabase(myActivity).putMessage(R.string.key_usercache_client_nav_event,
                 new StatsEvent(myActivity, R.string.app_launched));
+        TripDiaryStateMachineReceiver.startForegroundIfNeeded(myActivity);
     }
 
     @Override

--- a/src/android/location/TripDiaryStateMachineForegroundService.java
+++ b/src/android/location/TripDiaryStateMachineForegroundService.java
@@ -1,0 +1,69 @@
+package edu.berkeley.eecs.emission.cordova.tracker.location;
+
+import android.app.Notification;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+
+import de.appplant.cordova.plugin.notification.ClickActivity;
+import edu.berkeley.eecs.emission.MainActivity;
+import edu.berkeley.eecs.emission.cordova.unifiedlogger.Log;
+import edu.berkeley.eecs.emission.cordova.unifiedlogger.NotificationHelper;
+
+/**
+ * Created by shankari on 1/30/18
+ * as a hopefully short-to-medium term workaround for
+ * https://github.com/e-mission/e-mission-data-collection/issues/164
+ */
+
+public class TripDiaryStateMachineForegroundService extends Service {
+    private static String TAG = "TripDiaryStateMachineForegroundService";
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        Log.d(this, TAG, "onStartCommand called with flags = " + flags +
+                " and startId = " + startId);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Log.d(this, TAG, "onStartCommand called on oreo+, starting foreground service");
+            // Go to the foreground with a dummy notification
+            Notification.Builder builder = NotificationHelper.getNotificationBuilderForApp(this,
+                    "background trip tracking started");
+            builder.setOngoing(true);
+
+            Intent activityIntent = new Intent(this, MainActivity.class);
+            activityIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+            PendingIntent activityPendingIntent = PendingIntent.getActivity(this, 0,
+                    activityIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+            builder.setContentIntent(activityPendingIntent);
+
+
+            int ONGOING_TRIP_ID = 6646464;
+            startForeground(ONGOING_TRIP_ID, builder.build());
+        } else {
+            Log.d(this, TAG, "onStartCommand called on pre-oreo, ignoring");
+        }
+
+        // We want this service to continue running until it is explicitly
+        // stopped, so return sticky.
+        return START_STICKY;
+    }
+
+    public void onDestroy() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Log.d(this, TAG, "onDestroy called, removing notification");
+            stopForeground(true);
+        } else {
+            Log.d(this, TAG, "onDestroy called on pre-oreo, ignoring");
+        }
+    }
+}

--- a/src/android/location/TripDiaryStateMachineReceiver.java
+++ b/src/android/location/TripDiaryStateMachineReceiver.java
@@ -186,6 +186,15 @@ public class TripDiaryStateMachineReceiver extends BroadcastReceiver {
         }
     }
 
+    public static void startForegroundIfNeeded(Context ctxt) {
+        Log.d(ctxt, TAG, "checking to see whether to start foreground service");
+        if(TripDiaryStateMachineService.getState(ctxt).equals(ctxt.getString(R.string.state_ongoing_trip))) {
+           Log.d(ctxt, TAG, "app restarted while in the ongoing state, starting foreground service ASAP");
+           Intent foregroundServiceIntent = new Intent(ctxt, TripDiaryStateMachineForegroundService.class);
+           ctxt.startService(foregroundServiceIntent);
+        }
+    }
+
     public static void restartCollection(Context ctxt) {
         /*
          Super hacky solution, but works for now. Steps are:

--- a/src/android/location/TripDiaryStateMachineService.java
+++ b/src/android/location/TripDiaryStateMachineService.java
@@ -206,6 +206,10 @@ public class TripDiaryStateMachineService extends Service implements
 
     }
 
+    private Intent getForegroundServiceIntent() {
+        return new Intent(this, TripDiaryStateMachineForegroundService.class);
+    }
+
     /*
      * Handles the transition based on the current state.
      * Assumes that the API client is already connected.
@@ -269,6 +273,7 @@ public class TripDiaryStateMachineService extends Service implements
 
     public void handleTripStart(Context ctxt, final GoogleApiClient apiClient, final String actionString) {
         Log.d(this, TAG, "TripDiaryStateMachineReceiver handleTripStart(" + actionString + ") called");
+
         if (actionString.equals(ctxt.getString(R.string.transition_exited_geofence))) {
             // Delete geofence
             final List<BatchResultToken<Status>> tokenList = new LinkedList<BatchResultToken<Status>>();
@@ -289,6 +294,7 @@ public class TripDiaryStateMachineService extends Service implements
                     String newState = fCtxt.getString(R.string.state_ongoing_trip);
                     if (batchResult.getStatus().isSuccess()) {
                         setNewState(newState);
+                        startService(getForegroundServiceIntent());
                         if (ConfigManager.getConfig(fCtxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Success moving to "+newState);
@@ -360,6 +366,7 @@ public class TripDiaryStateMachineService extends Service implements
                             }
                     if (batchResult.getStatus().isSuccess()) {
                         setNewState(newState);
+                        stopService(getForegroundServiceIntent());
                         if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Success moving to "+newState);


### PR DESCRIPTION
Without this fix, we get location updates only once or twice an hour and never
detect that the trip ended.
This is a short-term, potentially permanent, fix for #164

Also bump up the version number to reflect this change.