### PR TITLE
Fix location services tracking toggle on android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.datacollection"
-        version="1.1.0">
+        version="1.2.0">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really
@@ -72,6 +72,7 @@
                 <action android:name="local.transition.stopped_moving"></action>
                 <action android:name="local.transition.stop_tracking"></action>
                 <action android:name="local.transition.start_tracking"></action>
+                <action android:name="local.transition.tracking_error"></action>
             </intent-filter>
         </receiver>
         <service

--- a/plugin.xml
+++ b/plugin.xml
@@ -73,6 +73,7 @@
                 <action android:name="local.transition.stop_tracking"></action>
                 <action android:name="local.transition.start_tracking"></action>
                 <action android:name="local.transition.tracking_error"></action>
+                <action android:name="android.location.MODE_CHANGED"></action>
             </intent-filter>
         </receiver>
         <service

--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import edu.berkeley.eecs.emission.*;
+import edu.berkeley.eecs.emission.cordova.tracker.location.TripDiaryStateMachineService;
 import edu.berkeley.eecs.emission.cordova.tracker.wrapper.ConsentConfig;
 import edu.berkeley.eecs.emission.cordova.tracker.wrapper.LocationTrackingConfig;
 import edu.berkeley.eecs.emission.cordova.tracker.location.TripDiaryStateMachineReceiver;
@@ -156,20 +157,23 @@ public class DataCollectionPlugin extends CordovaPlugin {
         }
     }
 
+    /*
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         Log.d(cordova.getActivity(), TAG, "received onActivityResult("+requestCode+","+
                 resultCode+","+data.getDataString()+")");
         switch (requestCode) {
             case ENABLE_LOCATION_CODE:
-                Log.d(cordova.getActivity(), TAG, requestCode + " is our code, handling callback");
+                Activity mAct = cordova.getActivity();
+                Log.d(mAct, TAG, requestCode + " is our code, handling callback");
                 cordova.setActivityResultCallback(null);
                 final LocationSettingsStates states = LocationSettingsStates.fromIntent(data);
                 switch (resultCode) {
                     case Activity.RESULT_OK:
                         // All required changes were successfully made
                         Log.i(cordova.getActivity(), TAG, "All changes successfully made, reinitializing");
-                        cordova.getActivity().sendBroadcast(new Intent(cordova.getActivity().getString(R.string.transition_initialize)));
+                        NotificationHelper.cancelNotification(mAct, Constants.TRACKING_ERROR_ID);
+                        TripDiaryStateMachineService.restartFSMIfStartState(mAct);
                         break;
                     case Activity.RESULT_CANCELED:
                         // The user was asked to change settings, but chose not to
@@ -183,5 +187,6 @@ public class DataCollectionPlugin extends CordovaPlugin {
                 Log.d(cordova.getActivity(), TAG, "Got unsupported request code "+requestCode+ " , ignoring...");
         }
     }
+    */
 
 }

--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -149,7 +149,7 @@ public class DataCollectionPlugin extends CordovaPlugin {
         PendingIntent piFromIntent = intent.getParcelableExtra(NotificationHelper.RESOLUTION_PENDING_INTENT_KEY);
         if (piFromIntent != null) {
             try {
-                cordova.setActivityResultCallback(this);
+                // cordova.setActivityResultCallback(this);
                 cordova.getActivity().startIntentSenderForResult(piFromIntent.getIntentSender(), ENABLE_LOCATION_CODE, null, 0, 0, 0, null);
             } catch (IntentSender.SendIntentException e) {
                 NotificationHelper.createNotification(cordova.getActivity(), Constants.TRACKING_ERROR_ID, "Unable to resolve issue");

--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -8,14 +8,18 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import android.app.Activity;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentSender;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationSettingsStates;
 import com.google.gson.Gson;
 
 import java.util.HashMap;
@@ -31,7 +35,8 @@ import edu.berkeley.eecs.emission.cordova.unifiedlogger.NotificationHelper;
 import edu.berkeley.eecs.emission.cordova.usercache.BuiltinUserCache;
 
 public class DataCollectionPlugin extends CordovaPlugin {
-    public static String TAG = "DataCollectionPlugin";
+    public static final String TAG = "DataCollectionPlugin";
+    public static final int ENABLE_LOCATION_CODE = 362253;
 
     @Override
     public void pluginInitialize() {
@@ -135,4 +140,48 @@ public class DataCollectionPlugin extends CordovaPlugin {
         retVal.put("START_TRACKING", ctxt.getString(R.string.transition_start_tracking));
         return retVal;
     }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+        Log.d(cordova.getActivity(), TAG, "onNewIntent(" + intent.getDataString() + ")");
+        Log.d(cordova.getActivity(), TAG, "Found extras " + intent.getExtras());
+        PendingIntent piFromIntent = intent.getParcelableExtra(NotificationHelper.RESOLUTION_PENDING_INTENT_KEY);
+        if (piFromIntent != null) {
+            try {
+                cordova.setActivityResultCallback(this);
+                cordova.getActivity().startIntentSenderForResult(piFromIntent.getIntentSender(), ENABLE_LOCATION_CODE, null, 0, 0, 0, null);
+            } catch (IntentSender.SendIntentException e) {
+                NotificationHelper.createNotification(cordova.getActivity(), Constants.TRACKING_ERROR_ID, "Unable to resolve issue");
+            }
+        }
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        Log.d(cordova.getActivity(), TAG, "received onActivityResult("+requestCode+","+
+                resultCode+","+data.getDataString()+")");
+        switch (requestCode) {
+            case ENABLE_LOCATION_CODE:
+                Log.d(cordova.getActivity(), TAG, requestCode + " is our code, handling callback");
+                cordova.setActivityResultCallback(null);
+                final LocationSettingsStates states = LocationSettingsStates.fromIntent(data);
+                switch (resultCode) {
+                    case Activity.RESULT_OK:
+                        // All required changes were successfully made
+                        Log.i(cordova.getActivity(), TAG, "All changes successfully made, reinitializing");
+                        cordova.getActivity().sendBroadcast(new Intent(cordova.getActivity().getString(R.string.transition_initialize)));
+                        break;
+                    case Activity.RESULT_CANCELED:
+                        // The user was asked to change settings, but chose not to
+                        Log.e(cordova.getActivity(), TAG, "User chose not to change settings, dunno what to do");
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            default:
+                Log.d(cordova.getActivity(), TAG, "Got unsupported request code "+requestCode+ " , ignoring...");
+        }
+    }
+
 }

--- a/src/android/location/GeofenceExitIntentService.java
+++ b/src/android/location/GeofenceExitIntentService.java
@@ -66,8 +66,7 @@ public class GeofenceExitIntentService extends IntentService {
 			// https://github.com/e-mission/e-mission-data-collection/issues/128#issuecomment-250304943
 			if (parsedEvent.hasError()) {
 				Log.i(this, TAG, "Found error "+parsedEvent.getErrorCode()+
-								"moving to start state");
-				sendBroadcast(new Intent(getString(R.string.transition_tracking_error)));
+								"will be handled by MODE_CHANGE transition");
 			} else {
 				Log.i(this, TAG, "Got event with transition = "+parsedEvent.getGeofenceTransition()+
 					" but hasError = false, ignoring");

--- a/src/android/location/TripDiaryStateMachineReceiver.java
+++ b/src/android/location/TripDiaryStateMachineReceiver.java
@@ -6,10 +6,12 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.location.LocationManager;
 import android.preference.PreferenceManager;
 
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.LocationSettingsRequest;
 
 import org.apache.cordova.ConfigXmlParser;
 import org.json.JSONException;
@@ -21,6 +23,7 @@ import java.util.Set;
 
 import edu.berkeley.eecs.emission.BuildConfig;
 import edu.berkeley.eecs.emission.R;
+
 import edu.berkeley.eecs.emission.cordova.tracker.ConfigManager;
 import edu.berkeley.eecs.emission.cordova.tracker.sensors.BatteryUtils;
 import edu.berkeley.eecs.emission.cordova.tracker.wrapper.Battery;
@@ -76,7 +79,8 @@ public class TripDiaryStateMachineReceiver extends BroadcastReceiver {
                 context.getString(R.string.transition_stopped_moving),
                 context.getString(R.string.transition_stop_tracking),
                 context.getString(R.string.transition_start_tracking),
-                context.getString(R.string.transition_tracking_error)
+                context.getString(R.string.transition_tracking_error),
+                LocationManager.MODE_CHANGED_ACTION
         }));
 
         if (!validTransitions.contains(intent.getAction())) {

--- a/src/android/location/TripDiaryStateMachineService.java
+++ b/src/android/location/TripDiaryStateMachineService.java
@@ -287,6 +287,7 @@ public class TripDiaryStateMachineService extends Service implements
         if (actionString.equals(ctxt.getString(R.string.transition_tracking_error))) {
             NotificationHelper.createNotification(ctxt, Constants.TRACKING_ERROR_ID,
                     "Location tracking turned off. Please turn on for emission to work properly");
+            checkLocationSettings(TripDiaryStateMachineService.this, mApiClient);
             Log.i(this, TAG, "Already in the start state, so going to stay there");
         }
     }
@@ -494,6 +495,9 @@ public class TripDiaryStateMachineService extends Service implements
                             fApiClient.disconnect();
                         }
                     });
+                } else {
+                    // Geofence was not created properly. let's generate a tracking error so that the user is notified
+                    fCtxt.sendBroadcast(new Intent(fCtxt.getString(R.string.transition_tracking_error)));
                 }
             }
         }).start();

--- a/src/android/location/TripDiaryStateMachineService.java
+++ b/src/android/location/TripDiaryStateMachineService.java
@@ -17,7 +17,11 @@ import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.ResultCallback;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.location.ActivityRecognition;
+import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.LocationSettingsRequest;
+import com.google.android.gms.location.LocationSettingsResult;
+import com.google.android.gms.location.LocationSettingsStatusCodes;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -27,6 +31,7 @@ import edu.berkeley.eecs.emission.cordova.tracker.Constants;
 import edu.berkeley.eecs.emission.cordova.tracker.sensors.BatteryUtils;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.NotificationHelper;
 import edu.berkeley.eecs.emission.R;
+
 import edu.berkeley.eecs.emission.cordova.tracker.location.actions.ActivityRecognitionActions;
 import edu.berkeley.eecs.emission.cordova.tracker.location.actions.GeofenceActions;
 import edu.berkeley.eecs.emission.cordova.tracker.location.actions.LocationTrackingActions;
@@ -307,7 +312,7 @@ public class TripDiaryStateMachineService extends Service implements
                         } else {
                             NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                     "Error " + batchResult.getStatus().getStatusCode()+" while creating geofence");
-                            // checkLocationSettings();
+                            checkLocationSettings(TripDiaryStateMachineService.this, mApiClient);
                         }
                         if (ConfigManager.getConfig(fCtxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
@@ -328,6 +333,7 @@ public class TripDiaryStateMachineService extends Service implements
             NotificationHelper.createNotification(ctxt, Constants.TRACKING_ERROR_ID,
                     "Location tracking turned off. Please turn on for emission to work properly");
             setNewState(getString(R.string.state_start));
+            checkLocationSettings(TripDiaryStateMachineService.this, mApiClient);
         }
     }
 
@@ -379,7 +385,7 @@ public class TripDiaryStateMachineService extends Service implements
                         } else {
                             NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                     "Error " + batchResult.getStatus().getStatusCode()+" while creating geofence");
-                            // checkLocationSettings();
+                            checkLocationSettings(TripDiaryStateMachineService.this, mApiClient);
                         }
                         if (ConfigManager.getConfig(ctxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
@@ -460,7 +466,7 @@ public class TripDiaryStateMachineService extends Service implements
                                 } else {
                                     NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                             "Error " + status.getStatusCode()+" while creating geofence");
-                                    // checkLocationSettings();
+                                    checkLocationSettings(TripDiaryStateMachineService.this, mApiClient);
                                 }
                                 if (ConfigManager.getConfig(fCtxt).isSimulateUserInteraction()) {
                                     NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
@@ -498,7 +504,7 @@ public class TripDiaryStateMachineService extends Service implements
                     } else {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
                                 "Error " + batchResult.getStatus().getStatusCode() + " while creating geofence");
-                        // checkLocationSettings();
+                        checkLocationSettings(TripDiaryStateMachineService.this, mApiClient);
                     }
                     if (ConfigManager.getConfig(fCtxt).isSimulateUserInteraction()) {
                         NotificationHelper.createNotification(fCtxt, STATE_IN_NUMBERS,
@@ -546,45 +552,45 @@ public class TripDiaryStateMachineService extends Service implements
      * but no time to do that now.
      */
 
-    /*
-private void checkLocationSettings() {
-
-        LocationRequest request = new LocationTrackingActions(TripDiaryStateMachineService.this, mApiClient).getLocationRequest();
+    public static void checkLocationSettings(final Context ctxt, GoogleApiClient apiClient) {
+        LocationRequest request = new LocationTrackingActions(ctxt, apiClient).getLocationRequest();
+        Log.d(ctxt, TAG, "Checking location settings for request "+request);
         LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder()
                 .addLocationRequest(request);
 
         PendingResult<LocationSettingsResult> result =
-                LocationServices.SettingsApi.checkLocationSettings(mApiClient, builder.build());
+                LocationServices.SettingsApi.checkLocationSettings(apiClient, builder.build());
+        Log.d(ctxt, TAG, "Got back result "+result);
         result.setResultCallback(new ResultCallback<LocationSettingsResult>() {
             @Override
             public void onResult(LocationSettingsResult result) {
+                Log.d(ctxt, TAG, "Found location settings "+result.getLocationSettingsStates());
                 final Status status = result.getStatus();
                 switch (status.getStatusCode()) {
                     case LocationSettingsStatusCodes.SUCCESS:
                         // All location settings are satisfied. The client can initialize location
                         // requests here.
-                        Log.i(TripDiaryStateMachineService.this, TAG, "All settings are valid, nothing to show");
+                        Log.i(ctxt, TAG, "All settings are valid, nothing to show");
                     case LocationSettingsStatusCodes.RESOLUTION_REQUIRED:
                         // Location settings are not satisfied. But could be fixed by showing the user
                         // a dialog.
                         if (status.hasResolution()) {
-                            NotificationHelper.createNotification(TripDiaryStateMachineService.this, Constants.TRACKING_ERROR_ID,
+                            NotificationHelper.createNotification(ctxt, Constants.TRACKING_ERROR_ID,
                                     "Error " + status.getStatusCode() + " in location settings",
                                     status.getResolution());
                         } else {
-                            NotificationHelper.createNotification(TripDiaryStateMachineService.this, Constants.TRACKING_ERROR_ID,
+                            NotificationHelper.createNotification(ctxt, Constants.TRACKING_ERROR_ID,
                                     "Error " + status.getStatusCode() + " in location settings");
                         }
                         break;
                     case LocationSettingsStatusCodes.SETTINGS_CHANGE_UNAVAILABLE:
                         // Location settings are not satisfied. However, we have no way to fix the
                         // settings so we won't show the dialog.
-                        NotificationHelper.createNotification(TripDiaryStateMachineService.this, Constants.TRACKING_ERROR_ID,
+                        NotificationHelper.createNotification(ctxt, Constants.TRACKING_ERROR_ID,
                                 "Error " + status.getStatusCode() + " in location settings");
                         break;
                 }
             }
         });
     }
-        */
 }

--- a/src/android/location/TripDiaryStateMachineServiceOngoing.java
+++ b/src/android/location/TripDiaryStateMachineServiceOngoing.java
@@ -4,6 +4,7 @@ import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.location.LocationManager;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.preference.PreferenceManager;
@@ -25,6 +26,7 @@ import edu.berkeley.eecs.emission.cordova.tracker.ConfigManager;
 import edu.berkeley.eecs.emission.cordova.tracker.Constants;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.NotificationHelper;
 import edu.berkeley.eecs.emission.R;
+
 import edu.berkeley.eecs.emission.cordova.tracker.location.actions.ActivityRecognitionActions;
 import edu.berkeley.eecs.emission.cordova.tracker.location.actions.LocationTrackingActions;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.Log;
@@ -230,6 +232,9 @@ public class TripDiaryStateMachineServiceOngoing extends Service implements
         // - have initialize function as a reset, which stops any current stuff and starts the new one
         if (actionString.equals(ctxt.getString(R.string.transition_initialize))) {
             handleStart(ctxt, apiClient, actionString);
+        } else if (LocationManager.MODE_CHANGED_ACTION.equals(actionString)) {
+            // should we do a handleXXX() wrapper for this too?
+            TripDiaryStateMachineService.checkLocationSettings(ctxt, apiClient);
         } else if (currState.equals(ctxt.getString(R.string.state_start))) {
             handleStart(ctxt, apiClient, actionString);
         } else if (currState.equals(ctxt.getString(R.string.state_waiting_for_trip_start))) {
@@ -258,6 +263,7 @@ public class TripDiaryStateMachineServiceOngoing extends Service implements
             NotificationHelper.createNotification(ctxt, Constants.TRACKING_ERROR_ID,
                     "Location tracking turned off. Please turn on for emission to work properly");
             Log.i(this, TAG, "Already in the start state, so going to stay there");
+            TripDiaryStateMachineService.checkLocationSettings(ctxt, apiClient);
         }
         }
 
@@ -279,6 +285,7 @@ public class TripDiaryStateMachineServiceOngoing extends Service implements
             NotificationHelper.createNotification(ctxt, Constants.TRACKING_ERROR_ID,
                     "Location tracking turned off. Please turn on for emission to work properly");
             setNewState(getString(R.string.state_start));
+            TripDiaryStateMachineService.checkLocationSettings(ctxt, apiClient);
         } else {
             final String newState = ctxt.getString(R.string.state_tracking_stopped);
             stopEverything(ctxt, apiClient, actionString);
@@ -293,6 +300,7 @@ public class TripDiaryStateMachineServiceOngoing extends Service implements
             NotificationHelper.createNotification(ctxt, Constants.TRACKING_ERROR_ID,
                     "Location tracking turned off. Please turn on for emission to work properly");
             setNewState(getString(R.string.state_start));
+            TripDiaryStateMachineService.checkLocationSettings(ctxt, apiClient);
         }
     }
 

--- a/src/android/location/actions/GeofenceActions.java
+++ b/src/android/location/actions/GeofenceActions.java
@@ -130,6 +130,7 @@ public class GeofenceActions {
                 Log.d(mCtxt, TAG, "After waiting for location reading result, location is " + this.newLastLocation);
                 return this.newLastLocation;
             } catch (InterruptedException e) {
+                LocationServices.FusedLocationApi.removeLocationUpdates(mGoogleApiClient, geofenceLocationIntent);
                 Log.w(mCtxt, TAG, "Timed out waiting for location result, returning null ");
                 return null;
             }
@@ -160,33 +161,12 @@ public class GeofenceActions {
                 .setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
     }
 
-    ResultCallback<Status> locationCallback = new ResultCallback<Status>() {
-        Context mCtxt = GeofenceActions.this.mCtxt;
-        @Override
-        public void onResult(Status status) {
-            if (status.isSuccess()) {
-                Location mLastLocation = LocationServices.FusedLocationApi.getLastLocation(
-                        mGoogleApiClient);
-                if (mLastLocation != null) {
-                    LocationServices.GeofencingApi.addGeofences(mGoogleApiClient,
-                            createGeofenceRequest(mLastLocation.getLatitude(), mLastLocation.getLongitude()),
-                            getGeofenceExitPendingIntent(mCtxt))
-                            .await();
-                } else {
-                    notifyFailure();
-                }
-            } else {
-                notifyFailure();
-            }
-        }
-
         public void notifyFailure() {
             Log.w(mCtxt, TAG,
                     "Unable to detect current location even after forcing, will retry at next sync");
             NotificationHelper.createNotification(mCtxt, GEOFENCE_IN_NUMBERS,
                     "Unable to detect current location even after forcing, will retry at next sync");
         }
-    };
 
     /*
      * Returns the geofence request object to be used with the geofencing API.

--- a/src/android/location/actions/GeofenceActions.java
+++ b/src/android/location/actions/GeofenceActions.java
@@ -101,6 +101,7 @@ public class GeofenceActions {
         LocalBroadcastManager.getInstance(mCtxt).registerReceiver(new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
+                Log.i(mCtxt, TAG, "recieved broadcast intent "+intent);
                 synchronized(GeofenceActions.this) {
                     GeofenceActions.this.newLastLocation = intent.getParcelableExtra(GeofenceLocationIntentService.INTENT_RESULT_KEY);
                     GeofenceActions.this.notify();

--- a/src/android/location/actions/GeofenceActions.java
+++ b/src/android/location/actions/GeofenceActions.java
@@ -24,6 +24,7 @@ import com.google.android.gms.location.LocationRequest;
 import com.google.android.gms.location.LocationServices;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import edu.berkeley.eecs.emission.cordova.tracker.location.GeofenceExitIntentService;
@@ -146,13 +147,19 @@ public class GeofenceActions {
         }
         LocationTrackingConfig cfg = ConfigManager.getConfig(mCtxt);
         if (testLoc.getAccuracy() > cfg.getAccuracyThreshold()) {
+            Log.i(mCtxt, TAG, "testLoc.getAccuracy "+testLoc.getAccuracy()+
+                    " > " + cfg.getAccuracyThreshold() + " isValidLocation = false");
             return false; // too inaccurate. Note that a high accuracy number means a larger radius
             // of validity which effectively means a low accuracy
         }
         int fiveMins = 5 * 60 * 1000;
         if ((testLoc.getTime() - System.currentTimeMillis()) > fiveMins * 60) {
+            Log.i(mCtxt, TAG, "testLoc.getTime() = "+ new Date(testLoc.getTime()) +
+                    " testLoc.oldness "+(testLoc.getTime() - System.currentTimeMillis()) +
+                    " > " + fiveMins * 60 + " isValidLocation = false");
             return false; // too old
         }
+        Log.i(mCtxt, TAG, "isValidLocation = true. Yay!");
         return true;
     }
 


### PR DESCRIPTION
This fixes the issue with turning location services off in the `WAITING_FOR_TRIP_START` state.
That generates a tracking error, which then generates a notification asking people to turn on location services again.
Assuming the checkForLocationSettings fails, the generated notification prompts the user to turn on location services again,
and the data collection plugin then re-initializes the FSM so that we return to `WAITING_FOR_TRIP_START`