### PR TITLE
Minor fix to collect_settings.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "e-mission-data-collection",
-  "version": "1.3.2",
-  "description": "Simple package that stores all the connection settings that need to be configured",
+  "version": "1.3.3",
+  "description": "The main tracking for the e-mission platform",
   "cordova": {
     "id": "e-mission-data-collection",
     "platforms": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.datacollection"
-        version="1.3.2">
+        version="1.3.3">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/www/ui/ionic/js/collect-settings.js
+++ b/www/ui/ionic/js/collect-settings.js
@@ -128,11 +128,13 @@ angular.module('emission.main.control.collection', [])
 
     cch.forceTransition = function(transition) {
         cch.forceTransitionWrapper(transition).then(function(result) {
-            $rootScope.$broadcast('control.update.complete', 'forceTransition');
-            $ionicPopup.alert({template: 'success -> '+result});
+            $ionicPopup.alert({template: 'success -> '+result}).then(function() {
+                $rootScope.$broadcast('control.update.complete', 'forceTransition');
+            });
         }, function(error) {
-            $rootScope.$broadcast('control.update.complete', 'forceTransition');
-            $ionicPopup.alert({template: 'error -> '+error});
+            $ionicPopup.alert({template: 'error -> '+error}).then(function() {
+                $rootScope.$broadcast('control.update.complete', 'forceTransition');
+            });
         });
     };
 


### PR DESCRIPTION
Let's generate the broadcast notification after the user has closed
the alert, to give the FSM enough time to settle down. Otherwise, we run
into timing issues where we re-read the new value before the FSM is done
updating the state.

We should really do this in a more principled way, but don't want to embark on
a big native code rewrite at this point.

Also bump up the version number to indicate the change.

Testing done (in conjunction with
https://github.com/e-mission/e-mission-phone/commit/8deda1dbc9a38b34596c986f45d105eb83957289

- Cleared logs
- Toggled tracking
- Ensured that refreshScreen was not called
- Clicked on the button in the alert
- Ensured that refreshScreen was called and the final state was consistent with
  the toggle