### PR TITLE
Force the gson library to the last valid version that supports Java 1.6

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -112,7 +112,7 @@
 		</service>
     </config-file>
 
-    <framework src="com.google.code.gson:gson:+"/>
+    <framework src="com.google.code.gson:gson:2.8.5"/>
     <framework src="com.google.android.gms:play-services-location:$LOCATION_VERSION"/>
     <preference name="LOCATION_VERSION" default="11.0.1"/>
 


### PR DESCRIPTION
This fixes
https://github.com/e-mission/e-mission-docs/issues/475#issuecomment-559623057

@st-patrick, in case you want to review this