### PR TITLE
When geofenced, store the current geofence location

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.datacollection"
-        version="1.3.3">
+        version="1.4">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/ios/Location/TripDiaryActions.m
+++ b/src/ios/Location/TripDiaryActions.m
@@ -13,9 +13,11 @@
 #import "ConfigManager.h"
 #import "GeofenceActions.h"
 #import "DataUtils.h"
-
+#import "BEMBuiltinUserCache.h"
 
 @implementation TripDiaryActions
+
+static NSString* const GEOFENCE_LOC_KEY = @"CURR_GEOFENCE_LOCATION";
 
 + (void) resetFSM:(NSString*) transition withLocationMgr:(CLLocationManager*)locMgr {
     if ([transition isEqualToString:CFCTransitionForceStopTracking]) {
@@ -99,6 +101,10 @@
     CLCircularRegion *geofenceRegion = [[CLCircularRegion alloc] initWithCenter:currLoc.coordinate
                                                                          radius:[ConfigManager instance].geofence_radius
                                                                      identifier:kCurrGeofenceID];
+    [[BuiltinUserCache database] putLocalStorage:GEOFENCE_LOC_KEY
+        jsonValue:@{ @"type" : @"Point",
+            @"coordinates": @[@(currLoc.coordinate.longitude), @(currLoc.coordinate.latitude)]
+    }];
     
     geofenceRegion.notifyOnEntry = YES;
     geofenceRegion.notifyOnExit = YES;


### PR DESCRIPTION
So that it can be used for debugging. The location is stored in the database as a local entry, so it can be retrieved directly from the usercache.
This fixes https://github.com/e-mission/e-mission-docs/issues/433

+ bump up the version number