### PR TITLE
Add a check to see if we are initializing the state machine recursively

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.datacollection"
-        version="1.4.1">
+        version="1.4.2">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/ios/Location/TripDiaryStateMachine.m
+++ b/src/ios/Location/TripDiaryStateMachine.m
@@ -51,6 +51,13 @@ static NSString * const kCurrState = @"CURR_STATE";
 + (TripDiaryStateMachine*) instance {
     static dispatch_once_t once;
     static id sharedInstance;
+    
+    if (once != 0) {
+        [LocalNotificationManager
+         addNotification:[NSString stringWithFormat:@"once = %lu, found recursive call to instance creation, returning NULL on second call", once]];
+        return NULL;
+    }
+    
     dispatch_once(&once, ^{
         sharedInstance = [[self alloc] init];
         // when we create a new instance, we use it to register for notifications


### PR DESCRIPTION
If we are, we skip the call to allow the original call to complete.
This is part of the fix - the other part will be checked in to the
transition notifier shortly.
The matching PR is https://github.com/e-mission/e-mission-transition-notify/pull/22

This fixes https://github.com/e-mission/e-mission-transition-notify/issues/18