### PR TITLE
Handle android 11 "always" permission properly + Humanize android notification messages

### DIFF
--- a/res/android/values/dc_strings.xml
+++ b/res/android/values/dc_strings.xml
@@ -24,14 +24,14 @@
     <string name="unknown_error_location_settings">Unknown error while reading location, please check your settings</string>
     <string name="notify_curr_state">In state %1$s</string>
     <!-- TripDiaryStateMachineForegroundService -->
-    <string name="foreground_killed_email_log">Foreground service killed, Profile -> Email Log for debugging</string>
+    <string name="foreground_killed_email_log">Foreground service killed, report at Profile -> Upload Log</string>
     <!-- ConfigManager -->
     <string name="error_reading_stored_config">Error reading stored tracking config, reset to defaults</string>
     <!-- DataCollectionPlugin -->
-    <string name="unable_resolve_issue">Unrecoverable error in tracking. Profile -> Email Log for further investigation</string>
+    <string name="unable_resolve_issue">Unrecoverable error in tracking, report at Profile -> Upload Log</string>
     <!-- State notification displays-->
     <string name="local.state.waiting_for_trip_start">Ready for your next trip</string>
     <string name="local.state.ongoing_trip">Yay! You are on a trip, keep going!</string>
-    <string name="local.state.start">Can't start app, see next pop up</string>
+    <string name="local.state.start">Cannot start app, see next pop up</string>
     <string name="local.state.tracking_stopped">Stopped tracking; remember to re-enable</string>
 </resources>

--- a/res/android/values/dc_strings.xml
+++ b/res/android/values/dc_strings.xml
@@ -29,4 +29,9 @@
     <string name="error_reading_stored_config">Error reading stored tracking config, reset to defaults</string>
     <!-- DataCollectionPlugin -->
     <string name="unable_resolve_issue">Unrecoverable error in tracking. Profile -> Email Log for further investigation</string>
+    <!-- State notification displays-->
+    <string name="local.state.waiting_for_trip_start">Ready for your next trip</string>
+    <string name="local.state.ongoing_trip">Yay! You are on a trip, keep going!</string>
+    <string name="local.state.start">Can't start app, see next pop up</string>
+    <string name="local.state.tracking_stopped">Stopped tracking; remember to re-enable</string>
 </resources>

--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -161,8 +161,13 @@ public class DataCollectionPlugin extends CordovaPlugin {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
+      if (data == null) {
+        Log.d(cordova.getActivity(), TAG, "received onActivityResult(" + requestCode + "," +
+          resultCode + "," + "null data" + ")");
+      } else {
         Log.d(cordova.getActivity(), TAG, "received onActivityResult("+requestCode+","+
                 resultCode+","+data.getDataString()+")");
+      }
         // This will be a NOP if we are not handling the correct activity intent
                 mControlDelegate.onActivityResult(requestCode, resultCode, data);
         /*

--- a/src/android/location/ForegroundServiceComm.java
+++ b/src/android/location/ForegroundServiceComm.java
@@ -20,27 +20,27 @@ public class ForegroundServiceComm {
   private TripDiaryStateMachineForegroundService mService;
   private boolean mBound = false;
   private int nRecursion = 0;
-  private String pendingMsg = null;
+  private String pendingMsgState = null;
 
   public ForegroundServiceComm(Context context) {
     mCtxt = context;
     mCtxt.bindService(getForegroundServiceIntent(), connection, 0);
   }
 
-  public void setMessage(String msg) {
+  public void setNewState(String newState) {
     nRecursion++;
     if (mBound) {
       Log.d(mCtxt, TAG, "Service successfully bound, setting state");
-      mService.setStateMessage(msg);
+      mService.setStateMessage(newState);
     } else {
           Intent fsi = getForegroundServiceIntent();
         if (nRecursion < 5) {
           Log.d(mCtxt, TAG, "nRecursion = "+nRecursion+" rebinding ");
-          pendingMsg = msg;
+          pendingMsgState = newState;
           mCtxt.bindService(fsi, connection, 0);
         } else if (nRecursion < 10) {
           Log.d(mCtxt, TAG, "nRecursion = "+nRecursion+" restarting before rebind ");
-          pendingMsg = msg;
+          pendingMsgState = newState;
           TripDiaryStateMachineForegroundService.startProperly(mCtxt);
           mCtxt.bindService(fsi, connection, 0);
         } else {
@@ -67,8 +67,8 @@ public class ForegroundServiceComm {
       mService = binder.getService();
       Log.e(mCtxt, TAG, "Successfully bound to service "+ mService);
       mBound = true;
-      if (pendingMsg != null) {
-        setMessage(pendingMsg);
+      if (pendingMsgState != null) {
+        setNewState(pendingMsgState);
       }
     }
 

--- a/src/android/location/TripDiaryStateMachineService.java
+++ b/src/android/location/TripDiaryStateMachineService.java
@@ -110,7 +110,7 @@ public class TripDiaryStateMachineService extends Service {
         Log.d(this, TAG, "newState saved in prefManager is "+
                 PreferenceManager.getDefaultSharedPreferences(this).getString(
                         this.getString(R.string.curr_state_key), "not found"));
-        mComm.setMessage(this.getString(R.string.notify_curr_state, newState));
+        mComm.setNewState(newState);
         // Let's check the location settings every time we change the state instead of only on failure
         // This makes the rest of the code much simpler, allows us to catch issues as quickly as possible,
         // and

--- a/src/android/location/TripDiaryStateMachineServiceOngoing.java
+++ b/src/android/location/TripDiaryStateMachineServiceOngoing.java
@@ -114,7 +114,7 @@ public class TripDiaryStateMachineServiceOngoing extends Service {
         Log.d(this, TAG, "newState saved in prefManager is "+
                 PreferenceManager.getDefaultSharedPreferences(this).getString(
                         this.getString(R.string.curr_state_key), "not found"));
-        mComm.setMessage(this.getString(R.string.notify_curr_state, newState));
+        mComm.setNewState(newState);
         stopSelf();
     }
 

--- a/src/android/verification/SensorControlForegroundDelegate.java
+++ b/src/android/verification/SensorControlForegroundDelegate.java
@@ -23,7 +23,10 @@ import android.app.PendingIntent;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
+import android.provider.Settings;
+
 
 import com.google.android.gms.location.LocationSettingsStates;
 


### PR DESCRIPTION
- Make messages shorter
- Make them more human-understandable
- Popup app settings on android 11
  - to avoid issue with having to open settings anyway
  - and to deal with the fact that the app dialog will not pop up if the user select anything other than always the first time

This fixes https://github.com/e-mission/e-mission-docs/issues/608