### PR TITLE
Remove the "Foreground service killed" notification

### DIFF
--- a/res/android/values/dc_strings.xml
+++ b/res/android/values/dc_strings.xml
@@ -24,7 +24,7 @@
     <string name="unknown_error_location_settings">Unknown error while reading location, please check your settings</string>
     <string name="notify_curr_state">In state %1$s</string>
     <!-- TripDiaryStateMachineForegroundService -->
-    <string name="foreground_killed_email_log">Foreground service killed, report at Profile -> Upload Log</string>
+    <string name="killed_foreground_service_detected_restart">killed_foreground_service_detected_restart</string>
     <!-- ConfigManager -->
     <string name="error_reading_stored_config">Error reading stored tracking config, reset to defaults</string>
     <!-- DataCollectionPlugin -->

--- a/src/android/location/TripDiaryStateMachineForegroundService.java
+++ b/src/android/location/TripDiaryStateMachineForegroundService.java
@@ -20,6 +20,8 @@ import java.util.stream.Collectors;
 
 import edu.berkeley.eecs.emission.cordova.tracker.verification.SensorControlBackgroundChecker;
 import edu.berkeley.eecs.emission.cordova.tracker.ExplicitIntent;
+import edu.berkeley.eecs.emission.cordova.tracker.wrapper.StatsEvent;
+import edu.berkeley.eecs.emission.cordova.usercache.BuiltinUserCache;
 
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.Log;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.NotificationHelper;
@@ -181,7 +183,8 @@ public class TripDiaryStateMachineForegroundService extends Service {
         }
       }
       Log.d(ctxt, TAG, "Did not find foreground notification with ID " + TripDiaryStateMachineForegroundService.ONGOING_TRIP_ID + " in list " + Arrays.stream(activeNotifications).map(n -> n.getId()).collect(Collectors.toList()));
-      NotificationHelper.createNotification(ctxt, ONGOING_TRIP_ID + 1, ctxt.getString(R.string.foreground_killed_email_log));
+      // NotificationHelper.createNotification(ctxt, ONGOING_TRIP_ID + 1, ctxt.getString(R.string.foreground_killed_email_log));
+      BuiltinUserCache.getDatabase(ctxt).putMessage(R.string.key_usercache_client_error, new StatsEvent(ctxt, R.string.killed_foreground_service_detected_restart));
       TripDiaryStateMachineForegroundService.startProperly(ctxt);
       // It is not enough to move to the foreground; you also need to reinitialize tracking
       // https://github.com/e-mission/e-mission-docs/issues/580#issuecomment-700747931


### PR DESCRIPTION
And replace it with a client stats message.
This allows us to track when the service is killed without requesting user logs.
That, in turn, will let us know how complicated a fix we need to implement.

This is a partial fix for:
https://github.com/e-mission/e-mission-docs/issues/672