### PR TITLE
Initial fix for the issue in which calling `getUnusedAppRestrictions.get` twice in the same thread hangs

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.7.0">
+        version="1.7.1">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/android/verification/SensorControlBackgroundChecker.java
+++ b/src/android/verification/SensorControlBackgroundChecker.java
@@ -26,6 +26,8 @@ import org.json.JSONObject;
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import edu.berkeley.eecs.emission.cordova.tracker.Constants;
 import edu.berkeley.eecs.emission.cordova.tracker.ExplicitIntent;
@@ -143,15 +145,15 @@ public class SensorControlBackgroundChecker {
            * generateOpenAppSettingsNotification? Nothing in the NotificationManager indicates that
            * it needs to run on the UI thread either.
            */
-        ExecutorService executor = Executors.newSingleThreadExecutor();
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
-        executor.execute(() -> {
+        executor.schedule(() -> {
           if (!SensorControlChecks.checkUnusedAppsUnrestricted(ctxt)) {
             Log.i(ctxt, TAG, "all current settings and permissions are probably valid, but could be reset later");
             Log.i(ctxt, TAG, "don't generate a tracking error right now, but let's ask the user to avoid the reset ");
             generateOpenAppSettingsNotification(ctxt);
           }
-        });
+        }, 1, TimeUnit.MINUTES);
     }
 
     public static void generateOpenAppSettingsNotification(Context ctxt) {

--- a/src/android/verification/SensorControlChecks.java
+++ b/src/android/verification/SensorControlChecks.java
@@ -105,7 +105,9 @@ public class SensorControlChecks {
   public static boolean checkUnusedAppsUnrestricted(final Context ctxt) {
       ListenableFuture<Integer> future = PackageManagerCompat.getUnusedAppRestrictionsStatus(ctxt);
     try {
+      Log.i(ctxt, TAG, "About to call future.get to read the restriction status");
       Integer appRestrictionStatus = future.get();
+      Log.i(ctxt, TAG, "Received "+appRestrictionStatus+" from future.get");
       switch(appRestrictionStatus) {
         case UnusedAppRestrictionsConstants.ERROR: return false;
         case UnusedAppRestrictionsConstants.FEATURE_NOT_AVAILABLE: return true;
@@ -116,8 +118,10 @@ public class SensorControlChecks {
           return false;
       }
     } catch (ExecutionException | InterruptedException e) {
+      Log.e(ctxt, TAG, "Got exception from future.get" + e);
       return false;
     }
+    Log.e(ctxt, TAG, "Random final false");
     return false;
   }
 }

--- a/src/android/verification/SensorControlForegroundDelegate.java
+++ b/src/android/verification/SensorControlForegroundDelegate.java
@@ -28,6 +28,7 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.provider.Settings;
 
@@ -552,12 +553,17 @@ public class SensorControlForegroundDelegate {
       case SensorControlConstants.REMOVE_UNUSED_APP_RESTRICTIONS:
         Log.d(mAct, TAG, requestCode + " is our code, handling callback");
         Log.d(mAct, TAG, "Got unused app restrictions callback from launching app settings");
+        AsyncTask.execute(new Runnable() {
+          @Override
+          public void run() {
         if (SensorControlChecks.checkUnusedAppsUnrestricted(cordova.getActivity())) {
-          SensorControlBackgroundChecker.restartFSMIfStartState(cordova.getActivity());
+              // SensorControlBackgroundChecker.restartFSMIfStartState(cordova.getActivity());
           cordovaCallback.success();
         } else {
           cordovaCallback.error(cordova.getActivity().getString(R.string.unused_apps_restricted));
         }
+          }
+        });
         break;
       default:
         Log.d(cordova.getActivity(), TAG, "Got unsupported request code " + requestCode + " , ignoring...");


### PR DESCRIPTION
This is an initial fix for https://github.com/e-mission/e-mission-docs/issues/710
The fix involves invoking the method in a separate thread, with a delay if needed.