### PR TITLE
Minor fix to the notification checks

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.7.1">
+        version="1.7.2">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/ios/Verification/TripDiarySensorControlChecks.m
+++ b/src/ios/Verification/TripDiarySensorControlChecks.m
@@ -47,7 +47,7 @@
 +(BOOL)checkNotificationsEnabled {
     UIUserNotificationSettings* requestedSettings = [self REQUESTED_NOTIFICATION_TYPES];
     UIUserNotificationSettings* currSettings = [[UIApplication sharedApplication] currentUserNotificationSettings];
-    return requestedSettings.types == currSettings.types;
+    return (currSettings.types & requestedSettings.types) == requestedSettings.types;
 }
 
 +(UIUserNotificationSettings*) REQUESTED_NOTIFICATION_TYPES {


### PR DESCRIPTION
To ensure that we don't fail if we have more permissions than requested
https://github.com/e-mission/e-mission-docs/issues/722#issuecomment-1110510498

Without this fix, having sound enabled for app notifications would cause the
checks to fail to fail, since the requested flags = 5 and the actual flags = 7

With this fix, we bitwise and the two values to remove the excess permissions.
7 (111) & 5 (101) = 101 = 5 = requested permissions