### PR TITLE
:alien: Comment out all calls to `getExpirationDate`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-em-datacollection",
-  "version": "1.7.0",
+  "version": "1.7.5",
   "description": "The main tracking for the e-mission platform",
   "license": "BSD-3-clause",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.7.4">
+        version="1.7.5">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/ios/BEMAppDelegate.m
+++ b/src/ios/BEMAppDelegate.m
@@ -146,12 +146,15 @@
     NSLog(@"About to check whether a trip has ended");
     NSDictionary* localUserInfo = @{@"handler": completionHandler};
     
+    /*
+    Since we now use a locally stored string as the token, we don't need to refresh it asynchronously
+    but let's keep the calls to refresh in case we need to ever restore it
+    Note that this should really call forceRefreshToken instead of being a copy-paste
+
     [[AuthTokenCreationFactory getInstance] getExpirationDate:^(NSString *expirationDate, NSError *error) {
-        /*
          * Note that we do not condition any further tasks on this refresh. That is because, in general, we expect that
          * the token refreshed at this time will be used to push the next set of values. This is just pre-emptive refreshing,
          * to increase the chance that we will finish pushing our data within the 30 sec interval.
-         */
         if (error == NULL) {
             [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                        @"Finished refreshing token in background, new expiry is %@",expirationDate]
@@ -162,6 +165,7 @@
                                                showUI:TRUE];
         }
     }];
+    */
     [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName object:CFCTransitionRecievedSilentPush userInfo:localUserInfo];
     [AppDelegate checkNativeConsent];
 }

--- a/src/ios/Location/TripDiaryStateMachine.m
+++ b/src/ios/Location/TripDiaryStateMachine.m
@@ -451,12 +451,15 @@ static NSString * const kCurrState = @"CURR_STATE";
 
 - (void) forceRefreshToken
 {
+    /*
+    Since we now use a locally stored string as the token, we don't need to refresh it asynchronously
+    but let's keep the calls to refreshToken in case we need to ever restore it and just convert
+    forceRefreshToken to a NOP
+
     [[AuthTokenCreationFactory getInstance] getExpirationDate:^(NSString *expirationDate, NSError *error) {
-        /*
          * Note that we do not condition any further tasks on this refresh. That is because, in general, we expect that
          * the token refreshed at this time will be used to push the next set of values. This is just pre-emptive refreshing,
          * to increase the chance that we will finish pushing our data within the 30 sec interval.
-         */
         if (error == NULL) {
             [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                        @"Finished refreshing token in background, new expiry is %@", expirationDate]
@@ -467,6 +470,7 @@ static NSString * const kCurrState = @"CURR_STATE";
                                                showUI:TRUE];
         }
     }];
+    */
 }
 
 /*


### PR DESCRIPTION
Since our tokens never expire. We still keep the functionality in place in case we need to resurrect it - it took quite a while to figure out the hooks. Although, when we do so, we should combine the calls into one instead of having two copy-pasted locations.

Original change:
https://github.com/e-mission/cordova-jwt-auth/pull/46/commits/0ef812ce7a5252785621657b61a22aff078abb30