### PR TITLE
Enable OPGeofence by default

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.7.6">
+        version="1.7.7">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really


### PR DESCRIPTION
We've been testing the OPGeofence for a while, and it seems
- pretty stable, and
- not leading to too much drain

It is also going to become significantly more important if/when we remove the continuously-on foreground service, since the geofence transition is likely to be even more delayed if we are not in the foreground and are subject to more background restrictions.

https://developer.android.com/training/location/geofencing
> Alerts can be late. The geofence service doesn't continuously query for
location, so expect some latency when receiving alerts. Usually the latency is less than 2 minutes, even less when the device has been moving. If Background Location Limits are in effect, the latency is about 2-3 minutes on average. If the device has been stationary for a significant period of time, the latency may increase (up to 6 minutes).

> Note: On Android 8.0 (API level 26) and higher, if an app is running in the
> background while monitoring a geofence, then the device responds to
> geofencing events every couple of minutes.

So let's turn OPGeofence on all the time and hope to get quicker transitions than we would with the classic geofence

+ Add a hack that would delete any previous configs so that we don't have zombie configs sitting around confusing things. This can be removed in the next release.