### PR TITLE
:children_crossing: Make sure that the error message is positive

### DIFF
--- a/res/android/values/dc_strings.xml
+++ b/res/android/values/dc_strings.xml
@@ -27,7 +27,7 @@
     <string name="notifications_blocked">Notifications blocked, please enable</string>
     <string name="notifications_paused">Notifications paused. This can only be fixed by the app developer. Please report to your admin.</string>
     <string name="unused_apps_restricted">Please allow this app to read sensor data even if you launch it infrequently.</string>
-    <string name="fix_app_status_title">Incorrect app settings</string>
+    <string name="fix_app_status_title">Please update permissions</string>
     <string name="fix_app_status_text">Click to view and fix app status</string>
     <string name="error_location_settings">Error in location settings, click to resolve</string>
     <string name="unknown_error_location_settings">Unknown error while reading location, please check your settings</string>

--- a/res/ios/en.lproj/DCLocalizable.strings
+++ b/res/ios/en.lproj/DCLocalizable.strings
@@ -21,5 +21,5 @@
 "location_permission_off_enable" = "Insufficient location permissions, please enable";
 "activity_permission_off" = "Motion and Fitness permission off, please enable";
 "activity_permission_off_app_open" = "Motion and Fitness permission off, please fix in app settings";
-"fix_app_status_title" = "Incorrect app settings";
+"fix_app_status_title" = "Please update permissions";
 "fix_app_status_text" = "Click to view and fix app status";


### PR DESCRIPTION
per feedback from program admin

> My point is if the text in the first screen shot that you show is under your
control to message out, don’t call it an “incorrect app setting”, call it a “Google update, so please fix your settings!”, just something that lets them know positively that it isn’t something wrong with the app.  Make the messaging positive!

We don't really know that this is due to a Google update; it could also be due to the user going into the settings at any time and changing them. But let's at least change the messaging to be positive.

Corresponds to
https://github.com/e-mission/e-mission-phone/commit/74217affeb1bf9be5010f1dd9d40a4f506fb37ee

Not bumping up the plugin.xml since I don't want to go through the effort of making a new release just for this change. Instead, we will incorporate it in the next release (which should be the initial bluetooth integration).