### PR TITLE
⬆️ 🔥 Upgrade to API 33 (remove workaround)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.7.8">
+        version="1.7.9">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/plugin.xml
+++ b/plugin.xml
@@ -132,8 +132,6 @@
     <framework src="androidx.work:work-runtime:$ANDROIDX_WORK_VERSION"/>
     <preference name="ANDROIDX_WORK_VERSION" default="2.7.1"/>
 
-    <framework src="src/android/enable_api_31.gradle" custom="true" type="gradleReference" />
-
     <source-file src="src/android/DataCollectionPlugin.java" target-dir="src/edu/berkeley/eecs/emission/cordova/tracker"/>
     <source-file src="src/android/BootReceiver.java" target-dir="src/edu/berkeley/eecs/emission/cordova/tracker"/>
     <source-file src="src/android/Constants.java" target-dir="src/edu/berkeley/eecs/emission/cordova/tracker"/>

--- a/src/android/enable_api_31.gradle
+++ b/src/android/enable_api_31.gradle
@@ -1,7 +1,0 @@
-ext.postBuildExtras = {
-    android {
-        defaultConfig {
-            compileSdkVersion 32
-        }
-    }
-}


### PR DESCRIPTION
In android 10, the cordova team removed support for `compileSdkVersion` However, in order to support auto-reset of permissions, we needed to use a later SDK than the target.

After filing an issue in the cordova-android repo, we added this grade file as a workaround. However, they have now reintroduced it in android 11 https://github.com/apache/cordova-android/issues/1373#issuecomment-1127157694 *and* our compile and target SDKs have caught up anyway

So we can remove the workaround.

More detail at:
https://github.com/e-mission/e-mission-phone/pull/1016#issuecomment-1685113930