### PR TITLE
New battery optimization request permissions popup.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,6 +56,7 @@
         <!-- COARSE_LOCATION obfuscates the location to a city block, change to FINE_LOCATION for accuracy -->
         <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
         <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+        <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     </config-file>
 
     <config-file target="AndroidManifest.xml" parent="/manifest/application">

--- a/src/android/verification/SensorControlConstants.java
+++ b/src/android/verification/SensorControlConstants.java
@@ -7,6 +7,7 @@ public class SensorControlConstants {
     public static String LOCATION_PERMISSION = Manifest.permission.ACCESS_FINE_LOCATION;
     public static String BACKGROUND_LOC_PERMISSION = Manifest.permission.ACCESS_BACKGROUND_LOCATION;
     public static String MOTION_ACTIVITY_PERMISSION = Manifest.permission.ACTIVITY_RECOGNITION;
+    public static String REQUEST_BATTERY_PERMISSION = Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS;
 
     public static final int ENABLE_LOCATION_SETTINGS = 362253738;
     public static final int ENABLE_LOCATION_SETTINGS_MANUAL = 362253736;
@@ -18,6 +19,7 @@ public class SensorControlConstants {
     public static final int REMOVE_UNUSED_APP_RESTRICTIONS = 362253743;
     public static final int OPEN_APP_STATUS_PAGE = 362253744;
     public static final int OPEN_BATTERY_OPTIMIZATION_PAGE = 362253745;
+    public static final int IGNORE_BATTERY_OPTIMIZATIONS = 362253746;
 
     public static final String ENABLE_LOCATION_PERMISSION_ACTION = "ENABLE_LOCATION_PERMISSION";
     public static final String ENABLE_BACKGROUND_LOC_PERMISSION_ACTION = "ENABLE_BACKGROUND_LOC_PERMISSION";


### PR DESCRIPTION
Integrated the `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` permission so that users will just get a pop up now asking them to turn off battery optimization instead of having to go dig through their settings as per issue [980](https://github.com/e-mission/e-mission-docs/issues/980). 

This is also an extension of [this closed PR](https://github.com/e-mission/e-mission-data-collection/pull/208). I created this new PR to clean up the commit history as the previous PR was really hard to understand. 