### PR TITLE
Airplane and Foreground Service Fix

### DIFF
--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -64,8 +64,13 @@ public class DataCollectionPlugin extends CordovaPlugin {
     @Override
     public void onResume(boolean multitasking){
       Context ctxt = cordova.getActivity();
-      Log.d(ctxt, TAG, "On resume, check for foreground service.");
-      TripDiaryStateMachineForegroundService.checkForegroundNotification(ctxt);
+      Log.d(ctxt, TAG, "On resume, check for foreground service only if user has conesented.");
+
+      String reqConsent = ConfigManager.getReqConsent(ctxt);
+      if (ConfigManager.isConsented(ctxt, reqConsent)) {
+          Log.d(ctxt, TAG, "User has consented, proceed with foreground check.");
+          TripDiaryStateMachineForegroundService.checkForegroundNotification(ctxt);
+      } 
     }
 
     @Override

--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -62,6 +62,13 @@ public class DataCollectionPlugin extends CordovaPlugin {
     }
 
     @Override
+    public void onResume(boolean multitasking){
+      Context ctxt = cordova.getActivity();
+      Log.d(ctxt, TAG, "On resume, check for foreground service.");
+      TripDiaryStateMachineForegroundService.checkForegroundNotification(ctxt);
+    }
+
+    @Override
     public boolean execute(String action, JSONArray data, final CallbackContext callbackContext) throws JSONException {
         if (action.equals("launchInit")) {
             Log.d(cordova.getActivity(), TAG, "application launched, init is nop on android");

--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -13,6 +13,8 @@ import org.json.JSONObject;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.BroadcastReceiver;
 import android.content.IntentSender;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -44,6 +46,13 @@ public class DataCollectionPlugin extends CordovaPlugin {
 
     @Override
     public void pluginInitialize() {
+        // Register for airplane mode intent
+        // Because of background execution limits, must register this implicit intent at runtime, not in manifest
+        Context ctxt = cordova.getActivity();
+        IntentFilter filter = new IntentFilter(Intent.ACTION_AIRPLANE_MODE_CHANGED);
+        BroadcastReceiver tripDiaryReceiver = new TripDiaryStateMachineReceiver();
+        ctxt.registerReceiver(tripDiaryReceiver, filter);
+
         mControlDelegate = new SensorControlForegroundDelegate(this, cordova);
         final Activity myActivity = cordova.getActivity();
         BuiltinUserCache.getDatabase(myActivity).putMessage(R.string.key_usercache_client_nav_event,

--- a/src/android/location/TripDiaryStateMachineReceiver.java
+++ b/src/android/location/TripDiaryStateMachineReceiver.java
@@ -66,6 +66,17 @@ public class TripDiaryStateMachineReceiver extends BroadcastReceiver {
 	public void onReceive(Context context, Intent intent) {
         Log.i(context, TAG, "TripDiaryStateMachineReciever onReceive(" + context + ", " + intent + ") called");
 
+        // Check to see if the user came out of airplane mode as the FSM needs to be restarted if they did
+        if (intent.getAction() != null && intent.getAction().equals(Intent.ACTION_AIRPLANE_MODE_CHANGED)) {
+            boolean isAirplaneModeOn = intent.getBooleanExtra("state", false);
+            if (!isAirplaneModeOn) {
+                Log.d(context, TAG, "Airplane mode was turned off, restart FSM.");
+                context.sendBroadcast(new ExplicitIntent(context, R.string.transition_initialize));
+            } else {
+                Log.d(context, TAG, "Airplane mode was turned on.");
+            }
+        }
+
         // Next two calls copied over from the constructor, figure out if this is the best place to
         // put them
         validTransitions = new HashSet<String>(Arrays.asList(new String[]{

--- a/src/android/location/TripDiaryStateMachineReceiver.java
+++ b/src/android/location/TripDiaryStateMachineReceiver.java
@@ -71,7 +71,7 @@ public class TripDiaryStateMachineReceiver extends BroadcastReceiver {
             boolean isAirplaneModeOn = intent.getBooleanExtra("state", false);
             if (!isAirplaneModeOn) {
                 Log.d(context, TAG, "Airplane mode was turned off, restart FSM.");
-                context.sendBroadcast(new ExplicitIntent(context, R.string.transition_initialize));
+                SensorControlBackgroundChecker.restartFSMIfStartState(context);
             } else {
                 Log.d(context, TAG, "Airplane mode was turned on.");
             }


### PR DESCRIPTION
This pull request addresses both issue [1042](https://github.com/e-mission/e-mission-docs/issues/1042) and issue [1043](https://github.com/e-mission/e-mission-docs/issues/1043). It fixes the FSM being stuck in `local.start.state` whenever an user goes in and out of airplane mode. It also provides a solution for when the foreground service randomly disappears. 