### PR TITLE
🍏 🛜  iOS BLE Integration

### DIFF
--- a/src/ios/Location/TripDiaryActions.h
+++ b/src/ios/Location/TripDiaryActions.h
@@ -27,6 +27,8 @@
 + (void) stopTracking:(NSString*) transition withLocationMgr:(CLLocationManager*)locMgr;
 + (void) stopTrackingLocation:(CLLocationManager*) manager;
 
++ (void)startBLEMonitoring:(NSString*) transition withLocationMgr:(CLLocationManager*)locMgr;
+
 + (void)createGeofenceHere:(CLLocationManager *)manager withGeofenceLocator:(GeofenceActions *)locator
                    inState:(TripDiaryStates)currState;
 + (void)createGeofenceAtLocation:(CLLocationManager *)manager atLocation:(CLLocation*)currLoc;

--- a/src/ios/Location/TripDiaryActions.m
+++ b/src/ios/Location/TripDiaryActions.m
@@ -34,6 +34,7 @@ static NSString* const GEOFENCE_LOC_KEY = @"CURR_GEOFENCE_LOCATION";
     if ([transition isEqualToString:CFCTransitionInitialize]) {
         [self startTrackingSignificantLocationChanges:locMgr];
         [self startTrackingVisits:locMgr];
+        [self startBLEMonitoring:transition withLocationMgr:locMgr];
     }
 }
 
@@ -51,20 +52,31 @@ static NSString* const GEOFENCE_LOC_KEY = @"CURR_GEOFENCE_LOCATION";
 
 + (void)startBLEMonitoring:(NSString*) transition withLocationMgr:(CLLocationManager*)locMgr {
     // Note: We don't need to run `RequestAlwaysAuthorization`, already set in SensorControlForegroundDelegate.m.
-    if ([CLLocationManager isMonitoringAvailableForClass:[CLBeaconRegion class]]) {
+    if ([CLLocationManager isMonitoringAvailableForClass:[CLBeaconRegion class]]) { // May be unecessary
         // Match all beacons with the specified UUID (This _must_ be same for all OpenPATH Deployments)
         NSUUID *proximityUUID = [[NSUUID alloc] initWithUUIDString:OpenPATHBeaconUUID];
         
         // Create the region and begin monitoring it.
         CLBeaconRegion *region = [[CLBeaconRegion alloc] initWithUUID:proximityUUID identifier:OpenPATHBeaconIdentifier];
         [locMgr startMonitoringForRegion:region];
-
-        // Are these redundant? It appears the notificaitons are sent in the TDSM as well, after these methods are called...
-        [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
-                                                            object:CFCTransitionScanBLE];
+        
+        NSLog(@"Started Monitoring BLE Region %@ during transition %@ ", region, transition);
         return;
     }
+    // TODO: Add Error Handling:
+    //[[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
+    //                                                    object:CFCTransitionBLEScanStarted];
+}
 
++ (void)stopBLEMonitoring:(NSString*) transition withLocationMgr:(CLLocationManager*)locMgr {
+        NSUUID *proximityUUID = [[NSUUID alloc] initWithUUIDString:OpenPATHBeaconUUID];
+        CLBeaconRegion *region = [[CLBeaconRegion alloc] initWithUUID:proximityUUID identifier:OpenPATHBeaconIdentifier];
+        [locMgr stopMonitoringForRegion:region];
+
+        NSLog(@"Stopped Monitoring BLE Region %@ during transition %@ ", region, transition);
+        //[[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
+        //                                                    object:CFCTransitionBLEScanStopped];
+        // TODO: Handle BLEScanStopped when not expected
 }
 
 + (void)printGeofences:(CLLocationManager*)manager {

--- a/src/ios/Location/TripDiaryActions.m
+++ b/src/ios/Location/TripDiaryActions.m
@@ -49,6 +49,24 @@ static NSString* const GEOFENCE_LOC_KEY = @"CURR_GEOFENCE_LOCATION";
                                                         object:CFCTransitionTripEnded];
 }
 
++ (void)startBLEMonitoring:(NSString*) transition withLocationMgr:(CLLocationManager*)locMgr {
+    // Note: We don't need to run `RequestAlwaysAuthorization`, already set in SensorControlForegroundDelegate.m.
+    if ([CLLocationManager isMonitoringAvailableForClass:[CLBeaconRegion class]]) {
+        // Match all beacons with the specified UUID (This _must_ be same for all OpenPATH Deployments)
+        NSUUID *proximityUUID = [[NSUUID alloc] initWithUUIDString:OpenPATHBeaconUUID];
+        
+        // Create the region and begin monitoring it.
+        CLBeaconRegion *region = [[CLBeaconRegion alloc] initWithUUID:proximityUUID identifier:OpenPATHBeaconIdentifier];
+        [locMgr startMonitoringForRegion:region];
+
+        // Are these redundant? It appears the notificaitons are sent in the TDSM as well, after these methods are called...
+        [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
+                                                            object:CFCTransitionScanBLE];
+        return;
+    }
+
+}
+
 + (void)printGeofences:(CLLocationManager*)manager {
     CLCircularRegion* currRegion = NULL;
     

--- a/src/ios/Location/TripDiaryDelegate.h
+++ b/src/ios/Location/TripDiaryDelegate.h
@@ -42,4 +42,7 @@ monitoringDidFailForRegion:(CLRegion *)region
 - (void)locationManager:(CLLocationManager *)manager
        didUpdateHeading:(CLHeading *)newHeading;
 
+- (void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region;
+
+
 @end

--- a/src/ios/Location/TripDiaryDelegate.m
+++ b/src/ios/Location/TripDiaryDelegate.m
@@ -141,7 +141,7 @@
         
         [manager stopRangingBeaconsSatisfyingConstraint:constraint];
         [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
-                                                            object:CFCTransitionExitedBLERange];
+                                                            object:CFCTransitionBeaconLost];
         [LocalNotificationManager addNotification:
             [NSString stringWithFormat:@"Exited range of beacon: %@ in state %@",
                                     region.identifier, 
@@ -353,7 +353,7 @@
         satisfyingConstraint:(CLBeaconIdentityConstraint *)beaconConstraint {
     
     [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
-                                                        object:CFCTransitionEnteredBLERange];
+                                                        object:CFCTransitionBeaconFound];
 
     [LocalNotificationManager addNotification:
         [NSString stringWithFormat:@"Successfully found Beacons: %@ in state %@",

--- a/src/ios/Location/TripDiaryDelegate.m
+++ b/src/ios/Location/TripDiaryDelegate.m
@@ -125,7 +125,6 @@
                                                @"Location tracking failed with error %@", error]];
 }
 
-
 - (void)locationManager:(CLLocationManager *)manager
           didExitRegion:(CLRegion *)region {
     if([region.identifier compare:kCurrGeofenceID] != NSOrderedSame) {
@@ -302,6 +301,34 @@
 - (void)locationManager:(CLLocationManager *)manager didUpdateHeading:(CLHeading *)newHeading {
     [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                @"Got new heading %@", newHeading]];
+}
+
+// After scanning is set up (as above), this will be called when a given beacon is in range
+- (void)locationManager:(CLLocationManager *)manager didEnterRegion:(CLRegion *)region {
+    // We only monitor the entrance of BLE Regions...
+    if([region.identifier compare:OpenPATHBeaconIdentifier] != NSOrderedSame) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
+                                              object:CFCTransitionBLEFound];
+       return;
+    }
+     [LocalNotificationManager addNotification:
+        [NSString stringWithFormat:@"Received enterance for region %@ in state %@, ignoring",
+            region.identifier, 
+            [TripDiaryStateMachine getStateName:_tdsm.currState]]
+                                showUI:TRUE];
+}
+
+/* 
+ * TODO: Implement 2nd step to range beacons, making sure they stay
+ * within range for the duration of the trip
+ */
+
+// Ranging for beacons: "Step 2"
+- (void)locationManager:(CLLocationManager *)manager 
+        didRangeBeacons:(NSArray<CLBeacon *> *)beacons 
+        satisfyingConstraint:(CLBeaconIdentityConstraint *)beaconConstraint {
+    // TODO 
+    return;
 }
 
 @end

--- a/src/ios/Location/TripDiaryStateMachine.h
+++ b/src/ios/Location/TripDiaryStateMachine.h
@@ -40,10 +40,6 @@
 #define CFCTransitionBeaconFound @"T_BLE_BEACON_FOUND"
 #define CFCTransitionBeaconLost @"T_BLE_BEACON_LOST"
 #define CFCTransitionNOP @"T_NOP"
-// The following transitions are utilized only within the fleet implementation of OpenPATH
-#define CFCTransitionEnteredBLERange @"T_ENTERED_BLE_RANGE"
-#define CFCTransitionExitedBLERange @"T_EXITED_BLE_RANGE" // Different from "Failed to Find" -- this is when it's left range
-#define CFCTransitionBLENotFound @"T_BLE_NOT_FOUND"
 
 // The UUID & Identifier for BLE Beacons used in OpenPATH Fleet deployments
 #define OpenPATHBeaconUUID @"bf3df3b1-6e46-35fa-86e5-927c95dd096c"
@@ -77,6 +73,7 @@ typedef void(^GeofenceStatusCallback)(NSString* geofenceStatus);
 @property CLLocationManager *locMgr;
 @property CMMotionActivityManager *activityMgr;
 @property TripDiaryStates currState;
+@property bool isFleet;
 
 + (NSString*)getStateName:(TripDiaryStates) state;
 

--- a/src/ios/Location/TripDiaryStateMachine.h
+++ b/src/ios/Location/TripDiaryStateMachine.h
@@ -39,12 +39,12 @@
 #define CFCTransitionVisitEnded @"T_VISIT_ENDED"
 #define CFCTransitionNOP @"T_NOP"
 // The following transitions are utilized only within the fleet implementation of OpenPATH
-#define CFCTransitionScanBLE @"T_SCAN_FOR_BLE"
-#define CFCTransitionBLEFound @"T_BLE_FOUND"
+#define CFCTransitionEnteredBLERange @"T_ENTERED_BLE_RANGE"
+#define CFCTransitionExitedBLERange @"T_EXITED_BLE_RANGE" // Different from "Failed to Find" -- this is when it's left range
 #define CFCTransitionBLENotFound @"T_BLE_NOT_FOUND"
 
 // The UUID & Identifier for BLE Beacons used in OpenPATH Fleet deployments
-#define OpenPATHBeaconUUID @"426C7565-4368-6172-6D42-6561636F6E73"
+#define OpenPATHBeaconUUID @"bf3df3b1-6e46-35fa-86e5-927c95dd096c"
 #define OpenPATHBeaconIdentifier @"nrel.emission"
 
 /*
@@ -62,7 +62,6 @@ typedef enum : NSUInteger {
     kWaitingForTripStartState,
     kOngoingTripState,
     kTrackingStoppedState,
-    kScanningForBLEState
 } TripDiaryStates;
 
 typedef void(^GeofenceStatusCallback)(NSString* geofenceStatus);

--- a/src/ios/Location/TripDiaryStateMachine.h
+++ b/src/ios/Location/TripDiaryStateMachine.h
@@ -42,6 +42,11 @@
 #define CFCTransitionScanBLE @"T_SCAN_FOR_BLE"
 #define CFCTransitionBLEFound @"T_BLE_FOUND"
 #define CFCTransitionBLENotFound @"T_BLE_NOT_FOUND"
+
+// The UUID & Identifier for BLE Beacons used in OpenPATH Fleet deployments
+#define OpenPATHBeaconUUID @"426C7565-4368-6172-6D42-6561636F6E73"
+#define OpenPATHBeaconIdentifier @"nrel.emission"
+
 /*
  * We need to decide the format of the notifications. From what I can see, there are two main options:
  * - we have a standard name for the notifications from this machine, and use the "object" field to indicate with transition it is, or

--- a/src/ios/Location/TripDiaryStateMachine.h
+++ b/src/ios/Location/TripDiaryStateMachine.h
@@ -38,7 +38,10 @@
 #define CFCTransitionVisitStarted @"T_VISIT_STARTED"
 #define CFCTransitionVisitEnded @"T_VISIT_ENDED"
 #define CFCTransitionNOP @"T_NOP"
-
+// The following transitions are utilized only within the fleet implementation of OpenPATH
+#define CFCTransitionScanBLE @"T_SCAN_FOR_BLE"
+#define CFCTransitionBLEFound @"T_BLE_FOUND"
+#define CFCTransitionBLENotFound @"T_BLE_NOT_FOUND"
 /*
  * We need to decide the format of the notifications. From what I can see, there are two main options:
  * - we have a standard name for the notifications from this machine, and use the "object" field to indicate with transition it is, or
@@ -53,7 +56,8 @@ typedef enum : NSUInteger {
     kStartState,
     kWaitingForTripStartState,
     kOngoingTripState,
-    kTrackingStoppedState
+    kTrackingStoppedState,
+    kScanningForBLEState
 } TripDiaryStates;
 
 typedef void(^GeofenceStatusCallback)(NSString* geofenceStatus);

--- a/src/ios/Location/TripDiaryStateMachine.m
+++ b/src/ios/Location/TripDiaryStateMachine.m
@@ -22,6 +22,7 @@
 #import "DataUtils.h"
 
 #import <CoreMotion/CoreMotion.h>
+#import <Foundation/Foundation.h>
 
 @interface TripDiaryStateMachine() {
     TripDiaryDelegate* _locDelegate;
@@ -73,8 +74,14 @@ static NSString * const kCurrState = @"CURR_STATE";
     // TODO: clean this up. Put it into a separate class and potentially write a wrapper for it.
     // This is particularly important if we initialize the plugin before we have the consent
     // in that case, this needs to be a singleton that is initalized dynamically
-    NSObject* dynamicConfig = [[BuiltinUserCache database] getDocument:@"config/app_ui_config" withMetadata:false];
-    self.isFleet = false;//
+    NSDictionary* dynamicConfig = [[BuiltinUserCache database] getDocument:@"config/app_ui_config" withMetadata:false];
+    self.isFleet = false;
+    if (dynamicConfig != NULL && [[dynamicConfig allKeys] containsObject:@"tracking"]) {
+        NSDictionary* trackingObj = [dynamicConfig valueForKey:@"tracking"];
+        if ([[trackingObj allKeys] containsObject:@"bluetooth_only"]) {
+            self.isFleet = [trackingObj valueForKey:@"bluetooth_only"];
+        }
+    }
 
     
     /*

--- a/src/ios/Wrapper/BluetoothBLE.h
+++ b/src/ios/Wrapper/BluetoothBLE.h
@@ -11,7 +11,8 @@
 
 @interface BluetoothBLE : NSObject
 
-- (instancetype)initWithCLBeacon:(CLBeacon *)beacon andEventType:(NSString *) eventType;
+- (instancetype)initWithCLBeaconRegion:(CLBeaconRegion*) beaconRegion andEventType:(NSString*) eventType;
+- (instancetype)initWithCLBeacon:(CLBeacon *)beacon;
 - (instancetype)initFake:(NSString *)eventType anduuid:(NSString*) uuid andmajor:(int) major andminor:(int) minor;
 
 // fields from CLBeacon, modified to be easy to serialize and restore

--- a/src/ios/Wrapper/BluetoothBLE.m
+++ b/src/ios/Wrapper/BluetoothBLE.m
@@ -12,16 +12,31 @@
 
 @implementation BluetoothBLE
 
--(id) initWithCLBeacon:(CLBeacon*) beacon andEventType:(NSString*) eventType {
+-(id) initWithCLBeaconRegion:(CLBeaconRegion*) beaconRegion andEventType:(NSString*) eventType {
+    assert([eventType isEqualToString:@"REGION_ENTER"] || [eventType isEqualToString:@"REGION_EXIT"]);
     self = [super init];
-    self.uuid = beacon.UUID;
+    self.uuid = beaconRegion.UUID.UUIDString;
+    self.major = beaconRegion.major.integerValue;
+    self.minor = beaconRegion.minor.integerValue;
+    self.proximity = [BluetoothBLE proximityToString:CLProximityUnknown];
+    self.accuracy = -1;
+    self.rssi = -1;
+    
+    self.eventType = eventType;
+    self.ts = [DataUtils dateToTs:[NSDate now]];
+    return self;
+}
+
+-(id) initWithCLBeacon:(CLBeacon*) beacon {
+    self = [super init];
+    self.uuid = beacon.UUID.UUIDString;
     self.major = beacon.major.integerValue;
     self.minor = beacon.minor.integerValue;
     self.proximity = [BluetoothBLE proximityToString:beacon.proximity];
     self.accuracy = beacon.accuracy;
     self.rssi = beacon.rssi;
     
-    self.eventType = eventType;
+    self.eventType = @"RANGE_UPDATE"; // we only get CLBeacon objects on range updates
     self.ts = [DataUtils dateToTs:beacon.timestamp];
     return self;
 }


### PR DESCRIPTION
## Purpose
The purpose of this PR is to incorporate BLE Scanning into the OpenPATH Finite-State Machine, such that trips are only tracked when a registered BLE Beacon is present at the beginning of the trip. 


## Timeline
- [x] Set up the skeleton for the new FSM Changes (Will include diagram in a later post, once the FSM Changes are finalized)
- [ ] Alter the FSM, such that trips begin (e.g., a transition to the "ongoingTrip" state) only occurs when:
  1.  The user has exited the established Geofence, and then
  2. There is a beacon within range, shortly after the geofence exit
- [ ] Plumb through the BLE Data that will be recorded, such that beacon data is recorded to the database
- [ ] Run A-B Tests to determine that _only_ beacon trips are being checked 
  - [ ] Perform a trip with the beacon in range
  - [ ] Perform the same trip without the beacon in range 
- [x] Brainstorm additional travel edge cases, which may potentially include:
  - The presence of multiple beacons within range during the trip start
  - Lack of an accurate geofence.
    - E.x.: If a user commutes to work with a fleet car, walks to lunch, and drives elsewhere within another fleet car -- as written, the geofence wouldn't match beacon location)
  - False Positive when testing for beacon within range
    - E.x.: Personal car is parked next to fleet vehicle, what happens if beacon is picked up during this trip?
- [ ]  Adjust FSM / BLE Scan to address the issues described above.


## Further Reading
For information on this PR, please consult the following:
- https://github.com/e-mission/e-mission-docs/issues/1046
- https://github.com/e-mission/e-mission-docs/issues/1062
- https://github.com/e-mission/e-mission-data-collection/pull/219