### PR TITLE
💩 Hack to enable installing the app in a work profile

### DIFF
--- a/src/android/verification/SensorControlChecks.java
+++ b/src/android/verification/SensorControlChecks.java
@@ -111,7 +111,7 @@ public class SensorControlChecks {
       Integer appRestrictionStatus = future.get();
       Log.i(ctxt, TAG, "Received "+appRestrictionStatus+" from future.get");
       switch(appRestrictionStatus) {
-        case UnusedAppRestrictionsConstants.ERROR: return false;
+        case UnusedAppRestrictionsConstants.ERROR: return true;
         case UnusedAppRestrictionsConstants.FEATURE_NOT_AVAILABLE: return true;
         case UnusedAppRestrictionsConstants.DISABLED: return true;
         case UnusedAppRestrictionsConstants.API_30_BACKPORT:


### PR DESCRIPTION
For the fleet version of OpenPATH, we need to install the app on work phones. While this works for most users, users who BYOD might have a separate work profile on their personal phone. The work profile may have different settings than the personal profile.

We had a report from a GSA user that their "Pause app activity if unused" setting was grayed out, so they could not enable it and could not proceed in the app. Our speculation is that this is because the app has a system exemption from hibernation, which generates an error while querying, which causes us to return false. https://developer.android.com/topic/performance/app-hibernation#system-exemption

I am still not sure why it doesn't return `FEATURE_NOT_AVAILABLE` or `DISABLED` instead of `ERROR`. Both of those and in particular `DISABLED` appear to be more meaningful and would return `true` in our case.

```
        case UnusedAppRestrictionsConstants.FEATURE_NOT_AVAILABLE: return true;
        case UnusedAppRestrictionsConstants.DISABLED: return true;
```

> Any available Unused App Restrictions on the device are disabled for this
> app. In other words, this app is exempt from having its permissions
> automatically removed or being hibernated.

- Due to lack of time, we are not able to test this; just flipping this to see if it works.
- Ignoring all errors is bad, and we should clean this up to check for work profiles properly if this is indeed the issue. We may also have a file an issue against google to fix their implementation.