### PR TITLE
👷🔧 🪠 Plumb through support for requesting bluetooth scan permissions …

### DIFF
--- a/src/android/DataCollectionPlugin.java
+++ b/src/android/DataCollectionPlugin.java
@@ -62,10 +62,6 @@ public class DataCollectionPlugin extends CordovaPlugin {
                 new StatsEvent(myActivity, R.string.app_launched));
 
         TripDiaryStateMachineReceiver.initOnUpgrade(myActivity);
-
-        // Ask for bluetooth permissions
-        // We will change this with future releases, we just ran out of time implementing this into the front end
-        mControlDelegate.checkAndPromptBluetoothScanPermissions();
     }
 
     @Override
@@ -125,6 +121,14 @@ public class DataCollectionPlugin extends CordovaPlugin {
           Log.d(cordova.getActivity(), TAG, "checking fitness permissions");
           mControlDelegate.checkMotionActivityPermissions(callbackContext);
           return true;
+        } else if (action.equals("fixBluetoothPermissions")) {
+          Log.d(cordova.getActivity(), TAG, "fixing bluetooth permissions");
+          mControlDelegate.checkAndPromptBluetoothScanPermissions(callbackContext);
+          return true;
+        } else if (action.equals("isValidBluetoothPermissions")) {
+          Log.d(cordova.getActivity(), TAG, "checking bluetooth permissions");
+          mControlDelegate.checkBluetoothPermissions(callbackContext);
+          return true;
         } else if (action.equals("fixShowNotifications")) {
           Log.d(cordova.getActivity(), TAG, "fixing notification enable");
           mControlDelegate.checkAndPromptShowNotificationsEnabled(callbackContext);
@@ -152,10 +156,6 @@ public class DataCollectionPlugin extends CordovaPlugin {
         } else if (action.equals("isIgnoreBatteryOptimizations")) {
           Log.d(cordova.getActivity(), TAG, "checking ignored battery optimizations");
           mControlDelegate.checkIgnoreBatteryOptimizations(callbackContext);
-          return true;
-        } else if (action.equals("bluetoothScanPermissions")) {
-          Log.d(cordova.getActivity(), TAG, "requesting bluetooth scan permissions");
-          mControlDelegate.checkAndPromptBluetoothScanPermissions(callbackContext);
           return true;
         } else if (action.equals("storeBatteryLevel")) {
             Context ctxt = cordova.getActivity();

--- a/src/android/verification/SensorControlChecks.java
+++ b/src/android/verification/SensorControlChecks.java
@@ -77,6 +77,16 @@ public class SensorControlChecks {
       return version29Check || permCheck;
     }
 
+    // TODO: Figure out how to integrate this with the background code
+    // https://github.com/e-mission/e-mission-docs/issues/680#issuecomment-953403832
+    public static boolean checkBluetoothPermissions(final Context ctxt) {
+      // apps before version 31 did not need to prompt for bluetooth permissions
+      boolean version32Check = Build.VERSION.SDK_INT < Build.VERSION_CODES.S;
+      boolean permCheck = ContextCompat.checkSelfPermission(ctxt, SensorControlConstants.BLUETOOTH_SCAN) == PermissionChecker.PERMISSION_GRANTED;
+      Log.i(ctxt, TAG, "version32Check "+version32Check+" permCheck "+permCheck+" retVal = "+(version32Check || permCheck));
+      return version32Check || permCheck;
+    }
+
     public static boolean checkNotificationsEnabled(final Context ctxt) {
       NotificationManagerCompat nMgr = NotificationManagerCompat.from(ctxt);
       boolean appDisabled = nMgr.areNotificationsEnabled();

--- a/www/datacollection.js
+++ b/www/datacollection.js
@@ -41,11 +41,6 @@ var DataCollection = {
             exec(resolve, reject, "DataCollection", "isValidLocationPermissions", []);
         });
     },
-    bluetoothScanPermissions: function () {
-        return new Promise(function(resolve, reject) {
-            exec(resolve, reject, "DataCollection", "bluetoothScanPermissions", []);
-        });
-    },
     fixFitnessPermissions: function () {
         return new Promise(function(resolve, reject) {
             exec(resolve, reject, "DataCollection", "fixFitnessPermissions", []);
@@ -54,6 +49,16 @@ var DataCollection = {
     isValidFitnessPermissions: function () {
         return new Promise(function(resolve, reject) {
             exec(resolve, reject, "DataCollection", "isValidFitnessPermissions", []);
+        });
+    },
+    fixBluetoothPermissions: function () {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "DataCollection", "fixBluetoothPermissions", []);
+        });
+    },
+    isValidBluetoothPermissions: function () {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, "DataCollection", "isValidBluetoothPermissions", []);
         });
     },
     fixShowNotifications: function () {


### PR DESCRIPTION
…on android

As far as we can tell, iOS does not need any additional permissions to use the iBeacon API since we already have "always" location permissions. However, android requires the BLUETOOTH_SCAN permission https://developer.android.com/develop/connectivity/bluetooth/bt-permissions#declare-android12-or-higher

This change includes:
- removing the hack popup that shows up when the app is launched
- adding check and checkAndFix methods in the javascript -> plugin -> foreground checker
- adding a new check method to the list of checks
- invoking the method from the background checker so that we can prompt people to provide it if they don't already do so
- ensure that the background checker method is only run for fleet configs

Testing done:
- See screenshots in the related UI PR
- Without the fleet check, simulated trip start/end on a non-fleet config and got a notification saying that permissions were incorrect
- With the fleet check, retried, and did not get the notification