### PR TITLE
🔧 ⌛ Continue scanning for 5 minutes after the geofence exit

### DIFF
--- a/src/android/bluetooth/BluetoothService.java
+++ b/src/android/bluetooth/BluetoothService.java
@@ -113,7 +113,7 @@ public class BluetoothService extends Service {
 
                 numScans++;
 
-                if (numScans >= 4) {
+                if (numScans >= 10 * 60) {
                     // Once we have hit certain number of scans, stop and determine if any beacons are in range
                     isInRange();
                 }


### PR DESCRIPTION
The current implementation on android starts ranging for beacons after a geofence exit and gives up after 4 retries. This is known to work when the beacon is available at the start of the trip - e.g. walking to work with a beacon tracks, walking to work without a beacon does not.

But this may not work when the beacon is not at the start location. For example, if the geofence triggers as soon as a user leaves their work building, and then they have to walk several minutes to get to their car, the ranging will timeout and the trip will be missed. This is a bit less likely because our geofence radius is set to ~ half a block, but we still don't want to miss trips.

We should really handle this with monitoring versus ranging, but for now, we will at least bump up the duration for which the ranging happens.

The range callback is roughly once a minute
https://github.com/AltBeacon/android-beacon-library/blob/7af8419c404329ac7dc6001917b5962d2cd53a11/lib/src/main/java/org/altbeacon/beacon/RangeNotifier.java#L39

```
    /**
     * Called once per second to give an estimate of the mDistance to visible beacons
     * @param beacons a collection of <code>Beacon<code> objects that have been seen in the past second
     * @param region the <code>Region</code> object that defines the criteria for the ranged beacons
     */
    public void didRangeBeaconsInRegion(Collection<Beacon> beacons, Region region);
```

So let's scan 5 * 60 times (roughly 5 minutes) before giving up

This is the last change for https://github.com/e-mission/e-mission-docs/issues/1062 before we move to staging