### PR TITLE
Work profile fix

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.8.5">
+        version="1.8.7">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/android/verification/SensorControlChecks.java
+++ b/src/android/verification/SensorControlChecks.java
@@ -151,7 +151,7 @@ public class SensorControlChecks {
       Integer appRestrictionStatus = future.get();
       Log.i(ctxt, TAG, "Received "+appRestrictionStatus+" from future.get");
       switch(appRestrictionStatus) {
-        case UnusedAppRestrictionsConstants.ERROR: return true;
+        case UnusedAppRestrictionsConstants.ERROR: return false;
         case UnusedAppRestrictionsConstants.FEATURE_NOT_AVAILABLE: return true;
         case UnusedAppRestrictionsConstants.DISABLED: return true;
         case UnusedAppRestrictionsConstants.API_30_BACKPORT:


### PR DESCRIPTION
This PR addresses [this issue](https://github.com/e-mission/e-mission-docs/issues/1070).
- Adds in an additional check to see if app is installed on a work profile
- Reverts previous temporary fix 
- Bumps version number

**Testing Done**
I successfully went through the permissions process for the app while installed on both a work profile and personal profile. 