### PR TITLE
Stop tracking unwanted trips in fleet mode on iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.8.9">
+        version="1.8.10">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/ios/Location/TripDiaryStateMachine.m
+++ b/src/ios/Location/TripDiaryStateMachine.m
@@ -365,11 +365,17 @@ static NSString * const kCurrState = @"CURR_STATE";
 
     } else if ([transition isEqualToString:CFCTransitionVisitEnded]) { 
         if ([ConfigManager instance].ios_use_visit_notifications_for_detection) {
+            if (!self.isFleet) {
             // We first start tracking and then delete the geofence to make sure that we are always tracking something
             [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
             [TripDiaryActions deleteGeofence:self.locMgr];
             [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
                                                                 object:CFCTransitionTripStarted];
+            } else {
+                NSLog(@"Got transition %@ in state %@ with fleet mode, ignoring, no beacon found",
+                      transition,
+                      [TripDiaryStateMachine getStateName:self.currState]);
+            }
         }
     } else if ([transition isEqualToString:CFCTransitionTripStarted]) {
         [self setState:kOngoingTripState withChecks:TRUE];

--- a/src/ios/Location/TripDiaryStateMachine.m
+++ b/src/ios/Location/TripDiaryStateMachine.m
@@ -253,15 +253,17 @@ static NSString * const kCurrState = @"CURR_STATE";
                                                             object:CFCTransitionNOP];
     } else if ([transition isEqualToString:CFCTransitionBeaconFound]) {
         if (self.isFleet) {
-            NSLog(@"Got transition %@ in state %@ with fleet mode, starting location tracking",
-                  transition,
-                  [TripDiaryStateMachine getStateName:self.currState]);
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Got transition %@ in state %@ with fleet mode, starting location tracking",
+                                                       transition,
+                                                       [TripDiaryStateMachine getStateName:self.currState]]];
             [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
             [TripDiaryActions deleteGeofence:self.locMgr];
         } else {
-            NSLog(@"Got transition %@ in state %@ with fleet mode, not sure why this happened, starting location tracking anyway",
-                  transition,
-                  [TripDiaryStateMachine getStateName:self.currState]);
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Got transition %@ in state %@ with fleet mode, not sure why this happened, starting location tracking anyway",
+                                                       transition,
+                                                       [TripDiaryStateMachine getStateName:self.currState]]];
             [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
             [TripDiaryActions deleteGeofence:self.locMgr];
 
@@ -281,13 +283,15 @@ static NSString * const kCurrState = @"CURR_STATE";
         [self setState:kStartState withChecks:FALSE];
     } else if ([transition isEqualToString:CFCTransitionExitedGeofence]) {
         if (self.isFleet) {
-            NSLog(@"Got transition %@ in state %@ with fleet mode, checking for beacons before starting location tracking",
-                  transition,
-                  [TripDiaryStateMachine getStateName:self.currState]);
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Got transition %@ in state %@ with fleet mode, checking for beacons before starting location tracking",
+                                                       transition,
+                                                       [TripDiaryStateMachine getStateName:self.currState]]];
         } else {
-            NSLog(@"Got transition %@ in state %@ in non-fleet mode, starting location tracking",
-                  transition,
-                  [TripDiaryStateMachine getStateName:self.currState]);
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Got transition %@ in state %@ in non-fleet mode, starting location tracking",
+                                                       transition,
+                                                       [TripDiaryStateMachine getStateName:self.currState]]];
             // We first start tracking and then delete the geofence to make sure that we are always tracking something
             [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
             [TripDiaryActions deleteGeofence:self.locMgr];
@@ -331,13 +335,15 @@ static NSString * const kCurrState = @"CURR_STATE";
          */
 
         if (self.isFleet) {
-            NSLog(@"Got transition %@ in state %@ with fleet mode, checking for beacons before starting location tracking",
-                  transition,
-                  [TripDiaryStateMachine getStateName:self.currState]);
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Got transition %@ in state %@ with fleet mode, checking for beacons before starting location tracking",
+                                                       transition,
+                                                       [TripDiaryStateMachine getStateName:self.currState]]];
         } else {
-            NSLog(@"Got transition %@ in state %@ in non-fleet mode, starting location tracking",
-                  transition,
-                  [TripDiaryStateMachine getStateName:self.currState]);
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Got transition %@ in state %@ in non-fleet mode, starting location tracking",
+                                                       transition,
+                                                       [TripDiaryStateMachine getStateName:self.currState]]];
             // We first start tracking and then delete the geofence to make sure that we are always tracking something
             [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
             [TripDiaryActions deleteGeofence:self.locMgr];
@@ -347,15 +353,17 @@ static NSString * const kCurrState = @"CURR_STATE";
         }
     } else if ([transition isEqualToString:CFCTransitionBeaconFound]) {
         if (self.isFleet) {
-            NSLog(@"Got transition %@ in state %@ with fleet mode, starting location tracking",
-                  transition,
-                  [TripDiaryStateMachine getStateName:self.currState]);
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Got transition %@ in state %@ with fleet mode, starting location tracking",
+                                                       transition,
+                                                       [TripDiaryStateMachine getStateName:self.currState]]];
             [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
             [TripDiaryActions deleteGeofence:self.locMgr];
         } else {
-            NSLog(@"Got transition %@ in state %@ with fleet mode, not sure why this happened, starting location tracking anyway",
-                  transition,
-                  [TripDiaryStateMachine getStateName:self.currState]);
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Got transition %@ in state %@ with fleet mode, not sure why this happened, starting location tracking anyway",
+                                                       transition,
+                                                       [TripDiaryStateMachine getStateName:self.currState]]];
             [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
             [TripDiaryActions deleteGeofence:self.locMgr];
 
@@ -372,9 +380,10 @@ static NSString * const kCurrState = @"CURR_STATE";
                 [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
                                                                     object:CFCTransitionTripStarted];
             } else {
-                NSLog(@"Got transition %@ in state %@ with fleet mode, ignoring, no beacon found",
-                      transition,
-                      [TripDiaryStateMachine getStateName:self.currState]);
+                [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                           @"Got transition %@ in state %@ with fleet mode, ignoring, no beacon found",
+                                                           transition,
+                                                           [TripDiaryStateMachine getStateName:self.currState]]];
             }
         }
     } else if ([transition isEqualToString:CFCTransitionTripStarted]) {
@@ -452,8 +461,10 @@ static NSString * const kCurrState = @"CURR_STATE";
         }
     } else if ([transition isEqualToString:CFCTransitionTripEndDetected]) {
         if (self.isFleet) {
-            NSLog(@"Got transition %@ in state %@ with fleet mode, still seeing beacon but no location updates, ignoring",
-                  transition,  [TripDiaryStateMachine getStateName:self.currState]);
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Got transition %@ in state %@ with fleet mode, still seeing beacon but no location updates, ignoring",
+                                                       transition,
+                                                       [TripDiaryStateMachine getStateName:self.currState]]];
         } else {
             [TripDiaryActions createGeofenceHere:self.locMgr withGeofenceLocator:_geofenceLocator inState:self.currState];
         }
@@ -467,14 +478,18 @@ static NSString * const kCurrState = @"CURR_STATE";
         // on the other hand, maybe createGeofence will find that we are outside the geofence, so will generate CFCTransitionTripRestarted
         // so let's try to create the geofence here for consistency, but also force the EndTripTracking
         if (self.isFleet) {
-            NSLog(@"Got transition %@ in state %@ with fleet mode, beacon is gone, we need to stop tracking",
-                  transition,  [TripDiaryStateMachine getStateName:self.currState]);
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Got transition %@ in state %@ with fleet mode, beacon is gone, we need to stop tracking",
+                                                       transition,
+                                                       [TripDiaryStateMachine getStateName:self.currState]]];
             [TripDiaryActions createGeofenceHere:self.locMgr withGeofenceLocator:_geofenceLocator inState:self.currState];
             [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
                                                                 object:CFCTransitionEndTripTracking];
         } else {
-            NSLog(@"Got transition %@ in state %@ with non-fleet mode, beacon is gone, ignoring",
-                  transition,  [TripDiaryStateMachine getStateName:self.currState]);
+            [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                                       @"Got transition %@ in state %@ with non-fleet mode, beacon is gone, ignoring",
+                                                       transition,
+                                                       [TripDiaryStateMachine getStateName:self.currState]]];
         }
     } else if ([transition isEqualToString:CFCTransitionEndTripTracking]) {
         // [TripDiaryActions pushTripToServer];

--- a/src/ios/Location/TripDiaryStateMachine.m
+++ b/src/ios/Location/TripDiaryStateMachine.m
@@ -366,11 +366,11 @@ static NSString * const kCurrState = @"CURR_STATE";
     } else if ([transition isEqualToString:CFCTransitionVisitEnded]) { 
         if ([ConfigManager instance].ios_use_visit_notifications_for_detection) {
             if (!self.isFleet) {
-            // We first start tracking and then delete the geofence to make sure that we are always tracking something
-            [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
-            [TripDiaryActions deleteGeofence:self.locMgr];
-            [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
-                                                                object:CFCTransitionTripStarted];
+                // We first start tracking and then delete the geofence to make sure that we are always tracking something
+                [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
+                [TripDiaryActions deleteGeofence:self.locMgr];
+                [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
+                                                                    object:CFCTransitionTripStarted];
             } else {
                 NSLog(@"Got transition %@ in state %@ with fleet mode, ignoring, no beacon found",
                       transition,


### PR DESCRIPTION
Unwanted trips where there is no BLE beacon are happening on iPhone when using a fleet server. This is caused by not checking for fleet mode when receiving a VISIT_ENDED transition.

This can be tested by using an opcode for a fleet server then forcing a transition into VISIT_ENDED. In the unpatched code this triggers a trip start.

Log showing trip start:

```
In TripDiaryStateMachine, received transition T_VISIT_ENDED in state STATE_WAITING_FOR_TRIP_START
DEBUG: In TripDiaryStateMachine, received transition T_VISIT_ENDED in state STATE_WAITING_FOR_TRIP_START
data has 96 bytes, str has size 96
data has 69 bytes, str has size 69
started fine location tracking with accuracy = -1 and distanceFilter = 1
DEBUG: started fine location tracking with accuracy = -1 and distanceFilter = 1
In TripDiaryStateMachine, received transition T_TRIP_STARTED in state STATE_WAITING_FOR_TRIP_START
DEBUG: In TripDiaryStateMachine, received transition T_TRIP_STARTED in state STATE_WAITING_FOR_TRIP_START
data has 98 bytes, str has size 98
data has 69 bytes, str has size 69
Moved from STATE_WAITING_FOR_TRIP_START to STATE_ONGOING_TRIP
```

This was fixed by simply ignoring a VISIT_ENDED transition for fleet mode.

Log after patch, trip doesn't start:

```In TripDiaryStateMachine, received transition T_VISIT_ENDED in state STATE_WAITING_FOR_TRIP_START
DEBUG: In TripDiaryStateMachine, received transition T_VISIT_ENDED in state STATE_WAITING_FOR_TRIP_START
data has 97 bytes, str has size 97
data has 68 bytes, str has size 68
Got transition T_VISIT_ENDED in state STATE_WAITING_FOR_TRIP_START with fleet mode, ignoring, no beacon found
Ignoring silent push notification
THREAD WARNING: ['DataCollection'] took '10,231.5830' ms. Plugin should use a background thread.
DEBUG:parseState: state = STATE_WAITING_FOR_TRIP_START; 
      platformId = ios
DEBUG: parseState: state = STATE_WAITING_FOR_TRIP_START; 
      platformId = iOS
```