### PR TITLE
Patch holes that cause unwanted trips to be started in fleet/non-fleet modes.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.9.0">
+        version="1.9.1">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/android/location/TripDiaryStateMachineService.java
+++ b/src/android/location/TripDiaryStateMachineService.java
@@ -281,7 +281,8 @@ public class TripDiaryStateMachineService extends Service {
                 if (isFleet) {
                     Log.d(this, TAG, "Found beacon in fleet mode, starting location tracking");
                 } else {
-                    Log.e(this, TAG, "Found beacon in non-fleet mode, not sure why this happened, starting location tracking anyway");
+                    Log.e(this, TAG, "ERROR: Found beacon in non-fleet mode, not starting location tracking");
+                    return;
                 }
             }
 

--- a/src/ios/Location/TripDiaryStateMachine.m
+++ b/src/ios/Location/TripDiaryStateMachine.m
@@ -129,7 +129,7 @@ static NSString * const kCurrState = @"CURR_STATE";
     // currently only in `BEMDataCollection initWithConsent`
     // https://github.com/e-mission/e-mission-docs/issues/735#issuecomment-1179774103
     
-    if (![ConfigManager instance].is_duty_cycling && self.currState != kTrackingStoppedState) {
+    if (![ConfigManager instance].is_duty_cycling && self.currState != kTrackingStoppedState && !self.isFleet) {
         /* If we are not using geofencing, and the tracking is not manually turned off, then we don't need to listen
          to any transitions. We just turn on the tracking here and never stop. Turning off all transitions makes
          it easier for us to ignore silent push as well as the transitions generated from here.
@@ -240,7 +240,7 @@ static NSString * const kCurrState = @"CURR_STATE";
         // Start location services so that we can get the current location
         // We will receive the first location asynchronously
         [TripDiaryActions createGeofenceHere:self.locMgr withGeofenceLocator:_geofenceLocator inState:self.currState];
-        } else {
+        } else if (!self.isFleet) {
             // Technically, we don't need this since we move to the ongoing state in the init code.
             // but if tracking is stopped, we can skip that, and then if we turn it on again, we
             // need to turn everything on here as well
@@ -261,11 +261,9 @@ static NSString * const kCurrState = @"CURR_STATE";
             [TripDiaryActions deleteGeofence:self.locMgr];
         } else {
             [LocalNotificationManager addNotification:[NSString stringWithFormat:
-                                                       @"Got transition %@ in state %@ with fleet mode, not sure why this happened, starting location tracking anyway",
+                                                       @"ERROR: Got transition %@ in state %@ without fleet mode",
                                                        transition,
                                                        [TripDiaryStateMachine getStateName:self.currState]]];
-            [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
-            [TripDiaryActions deleteGeofence:self.locMgr];
 
         }
         [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
@@ -361,11 +359,9 @@ static NSString * const kCurrState = @"CURR_STATE";
             [TripDiaryActions deleteGeofence:self.locMgr];
         } else {
             [LocalNotificationManager addNotification:[NSString stringWithFormat:
-                                                       @"Got transition %@ in state %@ with fleet mode, not sure why this happened, starting location tracking anyway",
+                                                       @"ERROR: Got transition %@ in state %@ without fleet mode",
                                                        transition,
                                                        [TripDiaryStateMachine getStateName:self.currState]]];
-            [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
-            [TripDiaryActions deleteGeofence:self.locMgr];
 
         }
         [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName


### PR DESCRIPTION
1. Turning off duty cycling in fleet mode causes tracking to be turned on regardless of if there's a beacon or not.
2. Receiving a beacon found transition in non-fleet mode causes a trip to be started.

# Fix

1. Don't start tracking when duty cycling is turned off in fleet mode until we see a beacon.
2. Log this as an error and stay in the same state.

I wasn't able to test if tracking works in fleet mode when duty cycling is turned off since I don't have a beacon. But I was able to verify that it doesn't immediately go into an ongoing trip when duty cycling is turned of in fleet mode.