### PR TITLE
Stop tracking when duty cycling is turned off in fleet mode

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.9.1">
+        version="1.9.2">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/android/location/TripDiaryStateMachineService.java
+++ b/src/android/location/TripDiaryStateMachineService.java
@@ -281,8 +281,7 @@ public class TripDiaryStateMachineService extends Service {
                 if (isFleet) {
                     Log.d(this, TAG, "Found beacon in fleet mode, starting location tracking");
                 } else {
-                    Log.e(this, TAG, "ERROR: Found beacon in non-fleet mode, not starting location tracking");
-                    return;
+                    Log.e(this, TAG, "Found beacon in non-fleet mode, not sure why this happened, starting location tracking anyway");
                 }
             }
 

--- a/src/android/location/TripDiaryStateMachineService.java
+++ b/src/android/location/TripDiaryStateMachineService.java
@@ -281,7 +281,8 @@ public class TripDiaryStateMachineService extends Service {
                 if (isFleet) {
                     Log.d(this, TAG, "Found beacon in fleet mode, starting location tracking");
                 } else {
-                    Log.e(this, TAG, "Found beacon in non-fleet mode, not sure why this happened, starting location tracking anyway");
+                    Log.e(this, TAG, "ERROR: Found beacon in non-fleet mode, not starting location tracking");
+                    return;
                 }
             }
 

--- a/src/android/location/TripDiaryStateMachineServiceOngoing.java
+++ b/src/android/location/TripDiaryStateMachineServiceOngoing.java
@@ -13,9 +13,6 @@ import com.google.android.gms.tasks.Tasks;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import edu.berkeley.eecs.emission.cordova.tracker.ConfigManager;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.NotificationHelper;
 import edu.berkeley.eecs.emission.R;
@@ -51,8 +48,6 @@ public class TripDiaryStateMachineServiceOngoing extends Service {
     private String mTransition = null;
     private SharedPreferences mPrefs = null;
     private ForegroundServiceComm mComm = null;
-    private JSONObject config;
-    private boolean isFleet = false;
 
     public TripDiaryStateMachineServiceOngoing() {
         super();
@@ -62,16 +57,6 @@ public class TripDiaryStateMachineServiceOngoing extends Service {
     public void onCreate() {
         Log.i(this, TAG, "Service created. Initializing one-time variables!");
         mComm = new ForegroundServiceComm(this);
-
-        try {
-            JSONObject c = (JSONObject) UserCacheFactory.getUserCache(this).getDocument("config/app_ui_config", false);   
-            config = c;
-            isFleet = (config != null && config.has("tracking") && config.getJSONObject("tracking").getBoolean("bluetooth_only"));
-        } catch (JSONException e) {
-            Log.d(this, TAG, "Error reading config! " + e);
-            // TODO: Need to figure out what to do about the fleet flag when the config is invalid
-            // Original implementation by @louisg1337 had isFleet = true in that case (location tracking would not stop)
-        }
     }
 
     @Override
@@ -173,17 +158,9 @@ public class TripDiaryStateMachineServiceOngoing extends Service {
         Log.d(this, TAG, "TripDiaryStateMachineReceiver handleStarted(" + actionString + ") called");
         // Get current location
         if (actionString.equals(ctxt.getString(R.string.transition_initialize)) &&
-            !mCurrState.equals(ctxt.getString(R.string.state_tracking_stopped))) {
-            if (isFleet) {
-                // Start up the bluetooth service to check for beacons
-                Intent foregroundStartBluetooth = new Intent(ctxt, TripDiaryStateMachineForegroundService.class);
-                foregroundStartBluetooth.setAction("foreground_start_bluetooth");
-                ctxt.startService(foregroundStartBluetooth);
-                setNewState(ctxt.getString(R.string.state_waiting_for_trip_start));
-            } else {
-                startEverything(ctxt, actionString);
-            }
-        }
+                !mCurrState.equals(ctxt.getString(R.string.state_tracking_stopped))) {
+            startEverything(ctxt, actionString);
+                    }
         if (actionString.equals(ctxt.getString(R.string.transition_stop_tracking))) {
             // Haven't started anything yet (that's why we are in the start state).
             // just move to the stop tracking state
@@ -208,11 +185,9 @@ public class TripDiaryStateMachineServiceOngoing extends Service {
     // If we stop tracking, we stop everything
     // For everything else, go to the ongoing state :)
     private void handleWaitingForTripStart(final Context ctxt, final String actionString) {
-        if (actionString.equals(getString(R.string.transition_exited_geofence)) && !isFleet) {
+        if (actionString.equals(getString(R.string.transition_exited_geofence))) {
             startEverything(ctxt, actionString);
-        } else if (actionString.equals(ctxt.getString(R.string.transition_ble_beacon_found)) && isFleet) {
-            startEverything(ctxt, actionString);
-        } else if (actionString.equals(getString(R.string.transition_start_tracking)) && !isFleet) {
+        } else if (actionString.equals(getString(R.string.transition_start_tracking))) {
             startEverything(ctxt, actionString);
         } else if (actionString.equals(ctxt.getString(R.string.transition_stop_tracking))) {
             // Haven't started anything yet (that's why we are in the start state).
@@ -245,11 +220,7 @@ public class TripDiaryStateMachineServiceOngoing extends Service {
     private void handleTrackingStopped(final Context ctxt, String actionString) {
         Log.d(this, TAG, "TripDiaryStateMachineReceiver handleTrackingStopped(" + actionString + ") called");
         if (actionString.equals(ctxt.getString(R.string.transition_start_tracking))) {
-            if (isFleet) {
-                setNewState(ctxt.getString(R.string.state_waiting_for_trip_start));
-            } else {
-                startEverything(ctxt, actionString);
-            }
+            startEverything(ctxt, actionString);
         }
         if (actionString.equals(ctxt.getString(R.string.transition_tracking_error))) {
             Log.i(this, TAG, "Tracking manually turned off, no need to prompt for location");


### PR DESCRIPTION
We don't want duty cycling to be turned off in fleet mode because it would track trips in non-fleet vehicles. Having duty cycling off and still only trying to track trips in fleet vehicles doesn't make sense because tracking just fleet vehicles is a form of duty cycling.

This patch treats this event as an error rather than an intentional decision.

If we plan on removing this from the UI in fleet mode it might be a good idea to have it automatically try to turn duty cycling back on.