### PR TITLE
🍎 iOS Permissions Changes to Comply with iOS Guidelines

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -212,19 +212,19 @@
     </config-file>
 
     <config-file target="*-Info.plist" parent="NSLocationAlwaysAndWhenInUseUsageDescription">
-        <string>OpenPATH requires "Precise" location access allowed "Always" to create an automatic trip diary</string>
+        <string>To create an automatic trip diary, "Precise" location access must be "Always" allowed</string>
     </config-file>
 
     <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
-        <string>OpenPATH also requires "Always" location access to track your trips in the background</string>
+        <string>To track your trips in the background, location access must be "Always" allowed</string>
     </config-file>
 
     <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
-        <string>OpenPATH requires "Precise" location access allowed "While Using App" to create an automatic trip diary</string>
+        <string>To create an automatic trip diary, "Precise" location access must be allowed "While Using App"</string>
     </config-file>
 
     <config-file target="*-Info.plist" parent="NSMotionUsageDescription">
-        <string>OpenPATH uses your phone's motion sensors to determine the modes of transportation during your trips</string>
+        <string>To determine the modes of transportation during your trips, the app must access your phone's motion sensors</string>
     </config-file>
 
     <config-file target="*-Info.plist" parent="ITSAppUsesNonExemptEncryption">
@@ -232,7 +232,7 @@
     </config-file>
 
     <config-file target="*-Info.plist" parent="NSBluetoothAlwaysUsageDescription">
-      <string>OpenPATH requires Bluetooth access to interact with BLE beacons for the fleet version of the app</string>
+      <string>To interact with BLE beacons for the fleet version of the app, Bluetooth access is required</string>
     </config-file>
 
     <podspec>

--- a/plugin.xml
+++ b/plugin.xml
@@ -212,19 +212,19 @@
     </config-file>
 
     <config-file target="*-Info.plist" parent="NSLocationAlwaysAndWhenInUseUsageDescription">
-        <string>We use your data to create an automatic trip diary</string>
+        <string>OpenPATH requires "Precise" location access allowed "Always" to create an automatic trip diary</string>
     </config-file>
 
     <config-file target="*-Info.plist" parent="NSLocationAlwaysUsageDescription">
-        <string>We use your data to create an automatic trip diary</string>
+        <string>OpenPATH also requires "Always" location access to track your trips in the background</string>
     </config-file>
 
     <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
-        <string>We use your data to create an automatic trip diary</string>
+        <string>OpenPATH requires "Precise" location access allowed "While Using App" to create an automatic trip diary</string>
     </config-file>
 
     <config-file target="*-Info.plist" parent="NSMotionUsageDescription">
-        <string>Our app uses the motion sensors to determine the transportation mode for the sections of your trip</string>
+        <string>OpenPATH uses your phone's motion sensors to determine the modes of transportation during your trips</string>
     </config-file>
 
     <config-file target="*-Info.plist" parent="ITSAppUsesNonExemptEncryption">
@@ -232,7 +232,7 @@
     </config-file>
 
     <config-file target="*-Info.plist" parent="NSBluetoothAlwaysUsageDescription">
-      <string>We need Bluetooth access to interact with BLE beacons for the fleet version of the app.</string>
+      <string>OpenPATH requires Bluetooth access to interact with BLE beacons for the fleet version of the app</string>
     </config-file>
 
     <podspec>

--- a/res/android/values/dc_strings.xml
+++ b/res/android/values/dc_strings.xml
@@ -17,9 +17,8 @@
     <!-- TripDiaryStateMachineService and Ongoing-->
     <string name="success_moving_new_state">Success moving to %1$s</string>
     <string name="failed_moving_new_state">Failed moving to %1$s</string>
-    <string name="location_permission_off">Insufficient location permissions, please fix</string>
-    <string name="location_permission_off_app_open">Insufficient location permissions, please fix in app settings</string>
-    <string name="location_permission_off_enable">Location permission off, click to enable</string>
+    <string name="location_permission_off">Insufficient permissions, please allow 'Always' and 'Precise' location access</string>
+    <string name="location_permission_off_app_open">Insufficient permissions, please select 'Always' and 'Precise' location access in app settings</string>
     <string name="location_permission_intermediary_title">Permissions Needed!</string>
     <string name="location_permission_intermediary_message">Further location permission needed. In order to use this app you need to click \"Allow all the time\" on the next page.</string>
     <string name="location_feedback_both_off">Please make sure \"Allow all the time\" and \"Precise Location\" are turned on in the settings.</string>

--- a/res/android/values/dc_strings.xml
+++ b/res/android/values/dc_strings.xml
@@ -32,7 +32,7 @@
     <string name="activity_permission_off">Activity permission off, please fix</string>
     <string name="activity_permission_off_app_open">Activity permission off, please fix in app settings</string>
     <string name="activity_permission_off_enable">Activity permission off, click to enable</string>
-    <string name="notifications_blocked">Notifications blocked, please enable</string>
+    <string name="notifications_blocked">Notifications blocked, you will not be able to receive reminders or alerts</string>
     <string name="notifications_paused">Notifications paused. This can only be fixed by the app developer. Please report to your admin.</string>
     <string name="unused_apps_restricted">Please allow this app to read sensor data even if you launch it infrequently.</string>
     <string name="fix_app_status_title">Please update permissions</string>

--- a/res/ios/en.lproj/DCLocalizable.strings
+++ b/res/ios/en.lproj/DCLocalizable.strings
@@ -15,9 +15,8 @@
 "precise-location-problem" = "The app does not have permission to read 'precise' location - background trip tracking will not work.";
 "notifications_blocked" = "Notifications blocked, you will not be able to receive reminders or alerts";
 "location_not_enabled" = "Location turned off, please turn on";
-"location_permission_off" = "Insufficient location permissions, please fix";
-"location_permission_off_app_open" = "Insufficient location permissions, please fix in app settings";
-"location_permission_off_enable" = "Insufficient location permissions, please enable";
+"location_permission_off" = "Insufficient permissions, please allow 'Always' and 'Precise' location access";
+"location_permission_off_app_open" = "Insufficient permissions, please select 'Always' and 'Precise' location access in app settings";
 "activity_permission_off" = "Motion and Fitness permission off, please enable";
 "activity_permission_off_app_open" = "Motion and Fitness permission off, please fix in app settings";
 "fix_app_status_title" = "Please update permissions";

--- a/res/ios/en.lproj/DCLocalizable.strings
+++ b/res/ios/en.lproj/DCLocalizable.strings
@@ -13,8 +13,7 @@
 "location-permission-problem" = "The app does not have the 'always' permission - background trip tracking will not work.";
 "fix-permission-action-button" = "Fix permission";
 "precise-location-problem" = "The app does not have permission to read 'precise' location - background trip tracking will not work.";
-"notifications_blocked" = "Notifications blocked, please enable";
-"notifications_blocked_app_open" = "Notifications blocked, please fix in app settings and then refresh";
+"notifications_blocked" = "Notifications blocked, you will not be able to receive reminders or alerts";
 "location_not_enabled" = "Location turned off, please turn on";
 "location_permission_off" = "Insufficient location permissions, please fix";
 "location_permission_off_app_open" = "Insufficient location permissions, please fix in app settings";

--- a/src/ios/Verification/SensorControlForegroundDelegate.m
+++ b/src/ios/Verification/SensorControlForegroundDelegate.m
@@ -272,8 +272,7 @@
                                    resultWithStatus:CDVCommandStatus_OK];
         [commandDelegate sendPluginResult:result callbackId:callbackId];
     } else {
-        NSString* msg = NSLocalizedStringFromTable(@"notifications_blocked_app_open", @"DCLocalizable", nil);
-        [self openAppSettings];
+        NSString* msg = NSLocalizedStringFromTable(@"notifications_blocked", @"DCLocalizable", nil);
         CDVPluginResult* result = [CDVPluginResult
                                    resultWithStatus:CDVCommandStatus_ERROR
                                    messageAsString:msg];

--- a/src/ios/Verification/SensorControlForegroundDelegate.m
+++ b/src/ios/Verification/SensorControlForegroundDelegate.m
@@ -259,10 +259,17 @@
 - (void)checkAndPromptNotificationPermission {
     NSString* callbackId = [command callbackId];
     @try {
-        if ([UIApplication instancesRespondToSelector:@selector(registerUserNotificationSettings:)]) {
-            UIUserNotificationSettings* requestedSettings = [TripDiarySensorControlChecks REQUESTED_NOTIFICATION_TYPES];
+        if ([[NSUserDefaults standardUserDefaults] boolForKey:@"HasPromptedForUserNotification"]) {
+            NSLog(@"Already prompted request for user notification. Launching app settings.");
             [AppDelegate registerForegroundDelegate:self];
-            [[UIApplication sharedApplication] registerUserNotificationSettings:requestedSettings];
+            [self openAppSettings];
+        } else {
+            if ([UIApplication instancesRespondToSelector:@selector(registerUserNotificationSettings:)]) {
+                NSLog(@"Requesting user notification settings");
+                UIUserNotificationSettings* requestedSettings = [TripDiarySensorControlChecks REQUESTED_NOTIFICATION_TYPES];
+                [AppDelegate registerForegroundDelegate:self];
+                [[UIApplication sharedApplication] registerUserNotificationSettings:requestedSettings];
+            }
         }
     }
     @catch (NSException *exception) {
@@ -275,6 +282,7 @@
 }
 
 - (void) didRegisterUserNotificationSettings:(UIUserNotificationSettings*)newSettings {
+    [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"HasPromptedForUserNotification"];
     NSString* callbackId = [command callbackId];
     UIUserNotificationSettings* requestedSettings = [TripDiarySensorControlChecks REQUESTED_NOTIFICATION_TYPES];
     if (requestedSettings.types == newSettings.types) {


### PR DESCRIPTION
As described in https://github.com/e-mission/e-mission-docs/issues/1094

- implements the "2-step strategy" for iOS 13.4+. If the user denies or gives insufficient permissions at any point in the process, subsequent attempts to fix the permission will just take them to the app settings page
- if user notifications permissions get denied, prevents app settings from immediately opening
- updates text for several permissions