### PR TITLE
🔥 Single-line changes to remove notification checks in the background checker

### DIFF
--- a/src/android/location/actions/GeofenceLocationIntentService.java
+++ b/src/android/location/actions/GeofenceLocationIntentService.java
@@ -111,8 +111,7 @@ public class GeofenceLocationIntentService extends IntentService {
     }
 
     private void broadcastLoc(Location loc) {
-        Intent answerIntent = new Intent(INTENT_NAME);
-        answerIntent.setPackage(this.getPackageName());
+        Intent answerIntent = new ExplicitIntent(this, INTENT_NAME);
         answerIntent.putExtra(INTENT_RESULT_KEY, loc);
         Log.i(this, TAG, "broadcasting intent "+answerIntent);
         LocalBroadcastManager.getInstance(this).sendBroadcast(answerIntent);

--- a/src/android/location/actions/GeofenceLocationIntentService.java
+++ b/src/android/location/actions/GeofenceLocationIntentService.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import edu.berkeley.eecs.emission.cordova.tracker.ExplicitIntent;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.Log;
 
 /**

--- a/src/android/verification/SensorControlBackgroundChecker.java
+++ b/src/android/verification/SensorControlBackgroundChecker.java
@@ -107,7 +107,6 @@ public class SensorControlBackgroundChecker {
         SensorControlChecks.checkLocationPermissions(ctxt),
         SensorControlChecks.checkIgnoreBatteryOptimizations(ctxt),
         SensorControlChecks.checkMotionActivityPermissions(ctxt),
-        SensorControlChecks.checkNotificationsEnabled(ctxt),
       };
       boolean allOtherChecksPass = true;
       for (boolean check: allOtherChecks) {

--- a/src/ios/Verification/SensorControlBackgroundChecker.m
+++ b/src/ios/Verification/SensorControlBackgroundChecker.m
@@ -47,8 +47,7 @@
       @([TripDiarySensorControlChecks checkLocationSettings]),
       @([TripDiarySensorControlChecks checkLocationPermissions]),
       @([TripDiarySensorControlChecks checkMotionActivitySettings]),
-      @([TripDiarySensorControlChecks checkMotionActivityPermissions]),
-      @([TripDiarySensorControlChecks checkNotificationsEnabled])
+      @([TripDiarySensorControlChecks checkMotionActivityPermissions])
     ];
     BOOL allChecksPass = TRUE;
     for (NSNumber* check in allChecks) {


### PR DESCRIPTION
As part of https://github.com/e-mission/e-mission-docs/issues/1094, we made the notification permission optional.

Since it is not required for silent push notifications, notifications are nice-to-have. They are still helpful to ensure that people know if there are issues, and hopefully help them label their trips, but the app will still work if the permission is turned off.

Since this is no longer required for normal operation, we don't need to check it in the background every hour, and nag the user to fix it if it is turned off. This is a super-easy change (two lines), so rolling this in while fixing https://github.com/e-mission/e-mission-docs/issues/1094 instead of coming in as a future fix.

Bonus fix: Use the ExplicitIntent wrapper in the geofence exit intent service to be consistent with all the other locations.