### PR TITLE
👔 Do not start a trip if we see a beacon in non-fleet mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-em-datacollection",
-  "version": "1.9.2",
+  "version": "1.9.5",
   "description": "The main tracking for the e-mission platform",
   "license": "BSD-3-clause",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.9.4">
+        version="1.9.5">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/ios/Location/TripDiaryStateMachine.m
+++ b/src/ios/Location/TripDiaryStateMachine.m
@@ -259,6 +259,8 @@ static NSString * const kCurrState = @"CURR_STATE";
                                                        [TripDiaryStateMachine getStateName:self.currState]]];
             [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
             [TripDiaryActions deleteGeofence:self.locMgr];
+            [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
+                                                                object:CFCTransitionTripStarted];
         } else {
             [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                        @"ERROR: Got transition %@ in state %@ without fleet mode",
@@ -266,8 +268,6 @@ static NSString * const kCurrState = @"CURR_STATE";
                                                        [TripDiaryStateMachine getStateName:self.currState]]];
 
         }
-        [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
-                                                            object:CFCTransitionTripStarted];
     } else if ([transition isEqualToString:CFCTransitionInitComplete]) {
         // Geofence has been successfully created and we are inside it so we are about to move to
         // the WAITING_FOR_TRIP_START state.
@@ -357,6 +357,8 @@ static NSString * const kCurrState = @"CURR_STATE";
                                                        [TripDiaryStateMachine getStateName:self.currState]]];
             [TripDiaryActions startTracking:transition withLocationMgr:self.locMgr];
             [TripDiaryActions deleteGeofence:self.locMgr];
+            [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
+                                                                object:CFCTransitionTripStarted];
         } else {
             [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                        @"ERROR: Got transition %@ in state %@ without fleet mode",
@@ -364,8 +366,6 @@ static NSString * const kCurrState = @"CURR_STATE";
                                                        [TripDiaryStateMachine getStateName:self.currState]]];
 
         }
-        [[NSNotificationCenter defaultCenter] postNotificationName:CFCTransitionNotificationName
-                                                            object:CFCTransitionTripStarted];
 
     } else if ([transition isEqualToString:CFCTransitionVisitEnded]) { 
         if ([ConfigManager instance].ios_use_visit_notifications_for_detection) {


### PR DESCRIPTION
Before this change, if we saw a beacon while in `WAITING_FOR_TRIP_START` state,
we would generate a `TripStarted` transition _regardless_ of whether it was a
fleet deployment or not. However, in fleet mode, we didn't actually start
fine-grained tracking. And when we received the geofence exit, we ignored it
because we were already in ONGOING_TRIP, so we didn't start fine-grained tracking.

This had two implications:
- we ended up with "straight-line" trips, because we didn't start fine-grained
  tracking, AND
- we would not show unpushed draft trips because the transition matching code
  expects to see an EXITED_GEOFENCE that it can match up with the end transitions

Testing done:

- Fleet configuration

```
In TripDiaryStateMachine, received transition T_BLE_BEACON_FOUND in state STATE_WAITING_FOR_TRIP_START
DEBUG: In TripDiaryStateMachine, received transition T_BLE_BEACON_FOUND in state STATE_WAITING_FOR_TRIP_START
data has 101 bytes, str has size 101
data has 69 bytes, str has size 69
ERROR: Got transition T_BLE_BEACON_FOUND in state STATE_WAITING_FOR_TRIP_START without fleet mode
DEBUG: ERROR: Got transition T_BLE_BEACON_FOUND in state STATE_WAITING_FOR_TRIP_START without fleet mode
Ignoring silent push notification
DEBUG:parseState: state = STATE_WAITING_FOR_TRIP_START;
      platformId = ios
```

- non-fleet configuration

```
In TripDiaryStateMachine, received transition T_BLE_BEACON_FOUND in state STATE_WAITING_FOR_TRIP_START
DEBUG: In TripDiaryStateMachine, received transition T_BLE_BEACON_FOUND in state STATE_WAITING_FOR_TRIP_START
data has 101 bytes, str has size 101
data has 67 bytes, str has size 67
Got transition T_BLE_BEACON_FOUND in state STATE_WAITING_FOR_TRIP_START with fleet mode, starting location tracking
DEBUG: Got transition T_BLE_BEACON_FOUND in state STATE_WAITING_FOR_TRIP_START with fleet mode, starting location tracking
started fine location tracking with accuracy = -1 and distanceFilter = 1
DEBUG: started fine location tracking with accuracy = -1 and distanceFilter = 1
In TripDiaryStateMachine, received transition T_TRIP_STARTED in state STATE_WAITING_FOR_TRIP_START
DEBUG: In TripDiaryStateMachine, received transition T_TRIP_STARTED in state STATE_WAITING_FOR_TRIP_START
data has 97 bytes, str has size 97
data has 69 bytes, str has size 69
Moved from STATE_WAITING_FOR_TRIP_START to STATE_ONGOING_TRIP
DEBUG: Moved from STATE_WAITING_FOR_TRIP_START to STATE_ONGOING_TRIP
```
