### PR TITLE
Increase logs to see when iOS is killing the app

### DIFF
--- a/src/ios/BEMAppDelegate.m
+++ b/src/ios/BEMAppDelegate.m
@@ -18,14 +18,10 @@
 #import "Cordova/CDVConfigParser.h"
 #import <objc/runtime.h>
 #import "AuthTokenCreationFactory.h"
-#import <MetricKit/MetricKit.h>
 
 @implementation AppDelegate (datacollection)
 
 + (BOOL)didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    // set up subscriber
-    [MXMetricManager.sharedManager addSubscriber:self];
-
     if ([UIApplication instancesRespondToSelector:@selector(registerUserNotificationSettings:)]) {
         [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings
                 settingsForTypes:UIUserNotificationTypeAlert|UIUserNotificationTypeBadge
@@ -57,9 +53,6 @@
     // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                @"Application went to the background"]];
-
-    //remove subscriber for metrics
-    [MXMetricManager.sharedManager removeSubscriber:self];
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
@@ -182,14 +175,6 @@
     if (!isConsented) {
         [LocalNotificationManager showNotification:NSLocalizedStringFromTable(@"new-data-collections-terms", @"DCLocalizable", nil)];
     }
-}
-
-- (void)didReceiveMetricPayloads:(NSArray<MXMetricPayload *> *)payloads
-{
-    [LocalNotificationManager addNotification:[NSString stringWithFormat:
-                                               @"didReceiveMetricPayloads %@",
-                                                [payloads.dictionaryRepresentation()]]
-                                       showUI:FALSE];
 }
 
 @end

--- a/src/ios/BEMAppDelegate.m
+++ b/src/ios/BEMAppDelegate.m
@@ -18,10 +18,14 @@
 #import "Cordova/CDVConfigParser.h"
 #import <objc/runtime.h>
 #import "AuthTokenCreationFactory.h"
+#import <MetricKit/MetricKit.h>
 
 @implementation AppDelegate (datacollection)
 
 + (BOOL)didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // set up subscriber
+    [MXMetricManager.sharedManager addSubscriber:self];
+
     if ([UIApplication instancesRespondToSelector:@selector(registerUserNotificationSettings:)]) {
         [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings
                 settingsForTypes:UIUserNotificationTypeAlert|UIUserNotificationTypeBadge
@@ -53,6 +57,9 @@
     // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                @"Application went to the background"]];
+
+    //remove subscriber for metrics
+    [MXMetricManager.sharedManager removeSubscriber:self];
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
@@ -175,6 +182,14 @@
     if (!isConsented) {
         [LocalNotificationManager showNotification:NSLocalizedStringFromTable(@"new-data-collections-terms", @"DCLocalizable", nil)];
     }
+}
+
+- (void)didReceiveMetricPayloads:(NSArray<MXMetricPayload *> *)payloads
+{
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                               @"didReceiveMetricPayloads %@",
+                                                [payloads.dictionaryRepresentation()]]
+                                       showUI:FALSE];
 }
 
 @end

--- a/src/ios/BEMDataCollection.m
+++ b/src/ios/BEMDataCollection.m
@@ -465,4 +465,9 @@ static NSString* const HAS_REQUESTED_NOTIFS_KEY = @"HasRequestedNotificationPerm
                                                @"onAppTerminate called"] showUI:FALSE];    
 }
 
+- (void) onMemoryWarning {
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                               @"onMemoryWarning called"] showUI:FALSE];    
+}
+
 @end


### PR DESCRIPTION
Based on lots of logs indicating that the iOS native code is being initialized, we think the OS is killing the app, increasing logs will help us figure out when this is happening and what is causing it. See [issue #1114](https://github.com/e-mission/e-mission-docs/issues/1114) for further details