### PR TITLE
Add Metric Kit

### DIFF
--- a/src/ios/BEMAppDelegate.h
+++ b/src/ios/BEMAppDelegate.h
@@ -9,12 +9,13 @@
 #import <UIKit/UIKit.h>
 #import "TripDiaryStateMachine.h"
 #import "AppDelegate.h"
+#import <MetricKit/MXMetricManager.h>
 #import "BEMServerSyncCommunicationHelper.h"
 #define NotificationCallback @"NOTIFICATION_CALLBACK"
 
-@interface AppDelegate (datacollection)
+@interface AppDelegate (datacollection) <MXMetricManagerSubscriber>
 
-+ (BOOL)didFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
+- (BOOL) didFinishLaunchingWithOptions:(NSDictionary *)launchOptions;
 + (NSString*) getReqConsent;
 + (void) checkNativeConsent;
 + (void) launchTripEndCheckAndRemoteSync:(void (^)(UIBackgroundFetchResult))completionHandler;

--- a/src/ios/BEMAppDelegate.m
+++ b/src/ios/BEMAppDelegate.m
@@ -187,8 +187,10 @@
 - (void)didReceiveMetricPayloads:(NSArray<MXMetricPayload *> *)payloads
 {
 //    TODO: handle payloads
-    NSLog(@"didReceiveMetricPayloads %@", payloads.firstObject.dictionaryRepresentation);
-    NSLog(@"applicationExitMetrics %@", payloads.firstObject.dictionaryRepresentation[@"applicationExitMetrics"]);
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                               @"didReceiveMetricPayloads %@", payloads.firstObject.dictionaryRepresentation]];
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                               @"applicationExitMetrics %@", payloads.firstObject.dictionaryRepresentation[@"applicationExitMetrics"]]];
 }
 
 @end

--- a/src/ios/BEMAppDelegate.m
+++ b/src/ios/BEMAppDelegate.m
@@ -187,7 +187,8 @@
 - (void)didReceiveMetricPayloads:(NSArray<MXMetricPayload *> *)payloads
 {
 //    TODO: handle payloads
-    NSLog(@"didReceiveMetricPayloads %@", payloads.firstObject.JSONRepresentation);
+    NSLog(@"didReceiveMetricPayloads %@", payloads.firstObject.dictionaryRepresentation);
+    NSLog(@"applicationExitMetrics %@", payloads.firstObject.dictionaryRepresentation[@"applicationExitMetrics"]);
 }
 
 @end

--- a/src/ios/BEMAppDelegate.m
+++ b/src/ios/BEMAppDelegate.m
@@ -18,10 +18,12 @@
 #import "Cordova/CDVConfigParser.h"
 #import <objc/runtime.h>
 #import "AuthTokenCreationFactory.h"
+#import <MetricKit/MetricKit.h>
+#import <MetricKit/MXMetricManager.h>
 
 @implementation AppDelegate (datacollection)
 
-+ (BOOL)didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+ - (BOOL) didFinishLaunchingWithOptions:(NSDictionary<UIApplicationLaunchOptionsKey, id> *)launchOptions{
     if ([UIApplication instancesRespondToSelector:@selector(registerUserNotificationSettings:)]) {
         [[UIApplication sharedApplication] registerUserNotificationSettings:[UIUserNotificationSettings
                 settingsForTypes:UIUserNotificationTypeAlert|UIUserNotificationTypeBadge
@@ -38,7 +40,10 @@
                                                @"Initialized remote push notification handler %@, finished registering for notifications ",
                                                 [BEMRemotePushNotificationHandler instance]]
                                        showUI:FALSE];
-
+     
+    //initialize the metric manager 
+    [MXMetricManager.sharedManager addSubscriber:self];
+    
     return YES;
 }
 
@@ -107,6 +112,8 @@
     [LocalNotificationManager showNotificationAfterSecs:[NSString stringWithFormat:NSLocalizedStringFromTable(@"dont-force-kill-please", @"DCLocalizable", nil)]
                                            withUserInfo:NULL
                                               secsLater:60];
+    //remove subscription for metric kit
+    [MXMetricManager.sharedManager removeSubscriber:self];
 }
 
 - (void)application:(UIApplication*)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
@@ -175,6 +182,12 @@
     if (!isConsented) {
         [LocalNotificationManager showNotification:NSLocalizedStringFromTable(@"new-data-collections-terms", @"DCLocalizable", nil)];
     }
+}
+
+- (void)didReceiveMetricPayloads:(NSArray<MXMetricPayload *> *)payloads
+{
+//    TODO: handle payloads
+    NSLog(@"didReceiveMetricPayloads %@", payloads.firstObject.JSONRepresentation);
 }
 
 @end

--- a/src/ios/BEMDataCollection.m
+++ b/src/ios/BEMDataCollection.m
@@ -64,7 +64,9 @@ static NSString* const HAS_REQUESTED_NOTIFS_KEY = @"HasRequestedNotificationPerm
     }
     [SensorControlBackgroundChecker checkAppState];
     NSDictionary* emptyOptions = @{};
-    [AppDelegate didFinishLaunchingWithOptions:emptyOptions];
+
+    AppDelegate *delegate = [AppDelegate new];
+    [delegate didFinishLaunchingWithOptions:emptyOptions];
 }
 
 - (void)markConsented:(CDVInvokedUrlCommand*)command
@@ -463,6 +465,11 @@ static NSString* const HAS_REQUESTED_NOTIFS_KEY = @"HasRequestedNotificationPerm
 - (void) onAppTerminate {
     [LocalNotificationManager addNotification:[NSString stringWithFormat:
                                                @"onAppTerminate called"] showUI:FALSE];    
+}
+
+- (void) onMemoryWarning {
+    [LocalNotificationManager addNotification:[NSString stringWithFormat:
+                                               @"onMemoryWarning called"] showUI:FALSE];
 }
 
 @end


### PR DESCRIPTION
Increasing metrics to dig into what is causing the app to be terminated in the background. 

We will probably want to do something better with the payloads as mentioned in [this comment](https://github.com/e-mission/e-mission-docs/issues/1114#issuecomment-2701856535). 

I'm waiting for developer access so I can test with a real phone in the loop (you can only simulate metric kit payloads with xcode on a real phone, not in the simulator). Once I see what the payloads look like, I can try to clean up how we process them. 

For now, this builds!