### PR TITLE
👔 Listen to beacons only for fleets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-em-datacollection",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "The main tracking for the e-mission platform",
   "license": "BSD-3-clause",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.9.5">
+        version="1.9.6">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/android/ConfigManager.java
+++ b/src/android/ConfigManager.java
@@ -10,6 +10,8 @@ import org.apache.cordova.ConfigXmlParser;
 import java.util.HashMap;
 
 import edu.berkeley.eecs.emission.R;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import edu.berkeley.eecs.emission.cordova.tracker.wrapper.ConsentConfig;
 import edu.berkeley.eecs.emission.cordova.tracker.wrapper.LocationTrackingConfig;
@@ -23,6 +25,9 @@ import edu.berkeley.eecs.emission.cordova.usercache.UserCacheFactory;
 public class ConfigManager {
     private static String TAG = "ConfigManager";
     private static LocationTrackingConfig cachedConfig;
+    private static ConsentConfig cachedConsent;
+    private static JSONObject cachedDynamicConfig;
+    private static boolean cachedIsFleet = false;
 
     public static LocationTrackingConfig getConfig(Context context) {
         if (cachedConfig == null) {
@@ -35,7 +40,7 @@ public class ConfigManager {
                 cachedConfig = new LocationTrackingConfig();
             }
             } catch(JsonParseException e) {
-                Log.e(context, TAG, "Found error " + e + "parsing sync config json, resetting to defaults");
+                Log.e(context, TAG, "Found error " + e + "parsing sensing config json, resetting to defaults");
                 NotificationHelper.createNotification(context, Constants.TRACKING_ERROR_ID,
                         null, context.getString(R.string.error_reading_stored_config));
                 cachedConfig = new LocationTrackingConfig();
@@ -63,11 +68,19 @@ public class ConfigManager {
         return reqConsent;
     }
 
+    public static ConsentConfig getConsent(Context context) throws JsonParseException {
+        if (cachedConsent == null) {
+            cachedConsent = UserCacheFactory.getUserCache(context)
+                .getDocument(R.string.key_usercache_consent_config, ConsentConfig.class);
+            Log.i(context, TAG, "Read cached consent "+cachedConsent+" from database");
+        }
+        return cachedConsent;
+    }
+
     public static boolean isConsented(Context context, String reqConsent) {
         try {
-        ConsentConfig currConfig = UserCacheFactory.getUserCache(context)
-                .getDocument(R.string.key_usercache_consent_config, ConsentConfig.class);
-        return currConfig != null && reqConsent.equals(currConfig.getApproval_date());
+            ConsentConfig currConfig = getConsent(context);
+            return currConfig != null && reqConsent.equals(currConfig.getApproval_date());
         } catch(JsonParseException e) {
             Log.e(context, TAG, "Found error " + e + "parsing consent json, re-prompting user");
             return false;
@@ -77,5 +90,26 @@ public class ConfigManager {
     public static void setConsented(Context context, ConsentConfig newConsent) {
         UserCacheFactory.getUserCache(context)
                 .putReadWriteDocument(R.string.key_usercache_consent_config, newConsent);
+    }
+
+    public static JSONObject getDynamicConfig(Context context) throws JSONException {
+        if (cachedDynamicConfig == null) {
+            cachedDynamicConfig = (JSONObject) UserCacheFactory.getUserCache(context).getDocument("config/app_ui_config", false);
+            cachedIsFleet = (cachedDynamicConfig != null &&
+                   cachedDynamicConfig.has("tracking") &&
+                   cachedDynamicConfig.getJSONObject("tracking").getBoolean("bluetooth_only"));
+        }
+        return cachedDynamicConfig;
+    }
+
+    public static boolean isFleet(Context ctxt) {
+        // this will populate the cached _is_fleet properly
+        try {
+            JSONObject dynamicConfig = getDynamicConfig(ctxt);
+        } catch (JSONException e) {
+            Log.e(ctxt, TAG, "ERROR "+e+" while reading dynamic config, returning default "+cachedIsFleet);
+        }
+        Log.d(ctxt, TAG, "found cached dynamicConfig, returning isFleet = "+cachedIsFleet);
+        return cachedIsFleet;
     }
 }

--- a/src/android/location/TripDiaryStateMachineService.java
+++ b/src/android/location/TripDiaryStateMachineService.java
@@ -63,15 +63,7 @@ public class TripDiaryStateMachineService extends Service {
         /*
          * Need to initialize once per create.
          */
-        try {
-            JSONObject c = (JSONObject) UserCacheFactory.getUserCache(this).getDocument("config/app_ui_config", false);   
-            config = c;
-            isFleet = (config != null && config.has("tracking") && config.getJSONObject("tracking").getBoolean("bluetooth_only"));
-        } catch (JSONException e) {
-            Log.d(this, TAG, "Error reading config! " + e);
-            // TODO: Need to figure out what to do about the fleet flag when the config is invalid
-            // Original implementation by @louisg1337 had isFleet = true in that case (location tracking would not stop)
-        }
+        isFleet = ConfigManager.isFleet(this);
     }
 
     @Override

--- a/src/android/location/TripDiaryStateMachineServiceOngoing.java
+++ b/src/android/location/TripDiaryStateMachineServiceOngoing.java
@@ -13,7 +13,6 @@ import com.google.android.gms.tasks.Tasks;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import edu.berkeley.eecs.emission.cordova.tracker.ConfigManager;
@@ -62,16 +61,7 @@ public class TripDiaryStateMachineServiceOngoing extends Service {
     public void onCreate() {
         Log.i(this, TAG, "Service created. Initializing one-time variables!");
         mComm = new ForegroundServiceComm(this);
-
-        try {
-            JSONObject c = (JSONObject) UserCacheFactory.getUserCache(this).getDocument("config/app_ui_config", false);   
-            config = c;
-            isFleet = (config != null && config.has("tracking") && config.getJSONObject("tracking").getBoolean("bluetooth_only"));
-        } catch (JSONException e) {
-            Log.d(this, TAG, "Error reading config! " + e);
-            // TODO: Need to figure out what to do about the fleet flag when the config is invalid
-            // Original implementation by @louisg1337 had isFleet = true in that case (location tracking would not stop)
-        }
+        isFleet = ConfigManager.isFleet(this);
     }
 
     @Override

--- a/src/android/verification/SensorControlBackgroundChecker.java
+++ b/src/android/verification/SensorControlBackgroundChecker.java
@@ -1,9 +1,7 @@
 package edu.berkeley.eecs.emission.cordova.tracker.verification; 
-// Auto fixed by post-plugin hook 
-import edu.berkeley.eecs.emission.R;
-// Auto fixed by post-plugin hook
 
-// Auto fixed by post-plugin hook
+import edu.berkeley.eecs.emission.R;
+
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -31,6 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import edu.berkeley.eecs.emission.cordova.tracker.ConfigManager;
 import edu.berkeley.eecs.emission.cordova.tracker.Constants;
 import edu.berkeley.eecs.emission.cordova.tracker.ExplicitIntent;
 import edu.berkeley.eecs.emission.cordova.tracker.location.TripDiaryStateMachineService;
@@ -92,16 +91,7 @@ public class SensorControlBackgroundChecker {
           // requests here.
           Log.i(ctxt, TAG, "All settings are valid, checking current state");
           Log.i(ctxt, TAG, "Current location settings are "+response);
-          boolean isFleet = false;
-          try {
-              JSONObject config = (JSONObject) UserCacheFactory.getUserCache(ctxt).getDocument("config/app_ui_config", false);   
-              isFleet = (config != null && config.has("tracking") && config.getJSONObject("tracking").getBoolean("bluetooth_only"));
-          } catch (JSONException e) {
-              Log.d(ctxt, TAG, "Error reading config! " + e);
-              // TODO: Need to figure out what to do about the fleet flag when the config is invalid
-              // Original implementation by @louisg1337 had isFleet = true in that case (location tracking would not stop)
-          }
-
+          boolean isFleet = ConfigManager.isFleet(ctxt);
           // Now that we know that the location settings are correct, we start the permission checks
       boolean[] allOtherChecks = new boolean[]{
         SensorControlChecks.checkLocationPermissions(ctxt),

--- a/src/ios/ConfigManager.h
+++ b/src/ios/ConfigManager.h
@@ -14,7 +14,13 @@
 
 + (LocationTrackingConfig*) instance;
 + (void) updateConfig:(LocationTrackingConfig*) newConfig;
+
++ (ConsentConfig*) consent_config;
 + (ConsentConfig*) getPriorConsent;
 + (BOOL) isConsented:(NSString*)reqConsent;
 + (void) setConsented:(ConsentConfig*) newConfig;
+
++ (NSDictionary*) dynamic_instance;
++ (BOOL) isFleet;
+
 @end

--- a/src/ios/Location/TripDiaryActions.m
+++ b/src/ios/Location/TripDiaryActions.m
@@ -51,6 +51,11 @@ static NSString* const GEOFENCE_LOC_KEY = @"CURR_GEOFENCE_LOCATION";
 }
 
 + (void)startBLEMonitoring:(NSString*) transition withLocationMgr:(CLLocationManager*)locMgr {
+    if (![ConfigManager isFleet]) {
+        [LocalNotificationManager addNotification:
+         [NSString stringWithFormat:@"Not a fleet deployment, skipping BLE monitoring!"]];
+        return;
+    }
     // Note: We don't need to run `RequestAlwaysAuthorization`, already set in SensorControlForegroundDelegate.m.
     if ([CLLocationManager isMonitoringAvailableForClass:[CLBeaconRegion class]]) { // May be unecessary
         // Match all beacons with the specified UUID (This _must_ be same for all OpenPATH Deployments)
@@ -60,7 +65,8 @@ static NSString* const GEOFENCE_LOC_KEY = @"CURR_GEOFENCE_LOCATION";
         CLBeaconRegion *region = [[CLBeaconRegion alloc] initWithUUID:proximityUUID identifier:OpenPATHBeaconIdentifier];
         [locMgr startMonitoringForRegion:region];
         
-        NSLog(@"Started Monitoring BLE Region %@ during transition %@ ", region, transition);
+        [LocalNotificationManager addNotification:
+         [NSString stringWithFormat:@"Started Monitoring BLE Region %@ during transition %@ ", region, transition]];
         return;
     }
     // TODO: Add Error Handling:

--- a/src/ios/Location/TripDiaryStateMachine.m
+++ b/src/ios/Location/TripDiaryStateMachine.m
@@ -71,18 +71,7 @@ static NSString * const kCurrState = @"CURR_STATE";
 - (id) init {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 
-    // TODO: clean this up. Put it into a separate class and potentially write a wrapper for it.
-    // This is particularly important if we initialize the plugin before we have the consent
-    // in that case, this needs to be a singleton that is initalized dynamically
-    NSDictionary* dynamicConfig = [[BuiltinUserCache database] getDocument:@"config/app_ui_config" withMetadata:false];
-    self.isFleet = false;
-    if (dynamicConfig != NULL && [[dynamicConfig allKeys] containsObject:@"tracking"]) {
-        NSDictionary* trackingObj = [dynamicConfig valueForKey:@"tracking"];
-        if ([[trackingObj allKeys] containsObject:@"bluetooth_only"]) {
-            self.isFleet = [trackingObj valueForKey:@"bluetooth_only"];
-        }
-    }
-
+    self.isFleet = [ConfigManager isFleet];
     
     /*
      * We are going to perform actions on the locMgr after this. So let us ensure that we create the loc manager first


### PR DESCRIPTION
Before this change, on android, we used to scan for beacons only for fleet deployments, but on iOS, we used to start scanning for beacons immediately on starting tracking, since the beacons are a "geofence-like" mechanism on iOS.

However, since we only do BLE matching in fleet mode, we can turn off scanning for non-fleet deployments, avoiding wasted working and reducing battery drain.

- This PR also includes refactoring of the codebase to pull out `isFleet` into a separate function that can be reused instead of copy-pasting the code in multiple places.
- As a bonus, it also refactors the consent code so that we read it once and then use the cached copy instead of going to the database every time we need to check the consent