### PR TITLE
🦕 Backwards compat for disabling BLE scans in non-fleet deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-em-datacollection",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "The main tracking for the e-mission platform",
   "license": "BSD-3-clause",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-datacollection"
-        version="1.9.6">
+        version="1.9.7">
 
   <name>DataCollection</name>
   <description>Background data collection FTW! This is the part that I really

--- a/src/ios/Location/TripDiaryActions.m
+++ b/src/ios/Location/TripDiaryActions.m
@@ -51,18 +51,20 @@ static NSString* const GEOFENCE_LOC_KEY = @"CURR_GEOFENCE_LOCATION";
 }
 
 + (void)startBLEMonitoring:(NSString*) transition withLocationMgr:(CLLocationManager*)locMgr {
+    // Match all beacons with the specified UUID (This _must_ be same for all OpenPATH Deployments)
+    NSUUID *proximityUUID = [[NSUUID alloc] initWithUUIDString:OpenPATHBeaconUUID];
+    
+    // Create the region and begin monitoring it.
+    CLBeaconRegion *region = [[CLBeaconRegion alloc] initWithUUID:proximityUUID identifier:OpenPATHBeaconIdentifier];
     if (![ConfigManager isFleet]) {
         [LocalNotificationManager addNotification:
-         [NSString stringWithFormat:@"Not a fleet deployment, skipping BLE monitoring!"]];
+         [NSString stringWithFormat:@"Not a fleet deployment, deleting existing BLE regions and skipping creation of new ones!"]];
+        // Apple docs: "If the specified region object is not currently being monitored, this method has no effect. "
+        [locMgr stopMonitoringForRegion:region];
         return;
     }
     // Note: We don't need to run `RequestAlwaysAuthorization`, already set in SensorControlForegroundDelegate.m.
     if ([CLLocationManager isMonitoringAvailableForClass:[CLBeaconRegion class]]) { // May be unecessary
-        // Match all beacons with the specified UUID (This _must_ be same for all OpenPATH Deployments)
-        NSUUID *proximityUUID = [[NSUUID alloc] initWithUUIDString:OpenPATHBeaconUUID];
-        
-        // Create the region and begin monitoring it.
-        CLBeaconRegion *region = [[CLBeaconRegion alloc] initWithUUID:proximityUUID identifier:OpenPATHBeaconIdentifier];
         [locMgr startMonitoringForRegion:region];
         
         [LocalNotificationManager addNotification:


### PR DESCRIPTION
In https://github.com/e-mission/e-mission-data-collection/commit/9e3704113f9c1d1159625deb4eaf411bf76f3f30 I skipped monitoring BLE regions for non-fleet deployments

However, apps that were installed before this change would have been monitoring for BLE regions, even in non-fleet deployments. If the app was simply updated instead of being uninstalled and reinstalled, we would skip turning on monitoring when the app was launched, but any existing monitoring would stay.

Similarly, if a user had signed in to a fleet deployment but then signed out and signed in to a non-fleet deployment, the existing monitoring would stay.

To handle both these cases and ensure that the monitoring is really and truly turned off in all non-fleet cases, we don't just skip turning the monitoring on, but explicitly turn the monitoring off in the non-fleet case.

Note that, per
https://developer.apple.com/documentation/corelocation/cllocationmanager/stopmonitoring(for:)?language=objc

> If the specified region object is not currently being monitored, this method has no effect.

so we don't need to check to see if the region object is monitored before stopping

Testing done:
- Ran with a non-fleet deployment and confirmed that the function is called; we don't start monitoring in the emulator because `isMonitoringAvailableForClass:[CLBeaconRegion class]` is false, so I cannot confirm that the region was deleted, but the app will not crash. We will verify that the region is actually deleted on staging